### PR TITLE
chore(deps): Node 22 LTS 상향 + GitHub Actions 5건 + 자동화 보강

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,3 +37,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      ci-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Detect package manager
         id: detect-package-manager
         run: |
@@ -61,14 +61,14 @@ jobs:
             exit 1
           fi
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         if: steps.detect-package-manager.outputs.manager == 'pnpm'
         with:
           version: latest
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
           cache-dependency-path: ${{ env.BUILD_PATH }}/${{ steps.detect-package-manager.outputs.lockfile }}
       - name: Setup Pages
@@ -85,7 +85,7 @@ jobs:
           PUBLIC_GOOGLE_SITE_VERIFICATION: ${{ secrets.PUBLIC_GOOGLE_SITE_VERIFICATION }}
           PUBLIC_GOOGLE_ANALYTICS_ID: ${{ secrets.PUBLIC_GOOGLE_ANALYTICS_ID }}
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ${{ env.BUILD_PATH }}/dist
 
@@ -99,4 +99,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -63,8 +63,6 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         if: steps.detect-package-manager.outputs.manager == 'pnpm'
-        with:
-          version: latest
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
         if: steps.detect-package-manager.outputs.manager == 'pnpm'
+        with:
+          version: 10.11.1
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: "📦 Install pnpm"
         uses: pnpm/action-setup@v6
-        with:
-          version: 10.11.1
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,19 +20,19 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20]
+        node-version: [22]
 
     steps:
       - name: "☁️ Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: "📦 Install pnpm"
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.11.1
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: "📦 Install pnpm"
         uses: pnpm/action-setup@v6
+        with:
+          version: 10.11.1
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": ">=22.0.0"
   },
+  "packageManager": "pnpm@10.11.1",
   "scripts": {
     "dev": "astro dev",
     "build": "astro check && astro build && pagefind --site dist && cp -r dist/pagefind public/",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "astro-paper",
   "type": "module",
   "version": "5.5.0",
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro check && astro build && pagefind --site dist && cp -r dist/pagefind public/",
@@ -61,22 +64,22 @@
     "overrides": {
       "astro>svgo": "4.0.1",
       "@iconify/tools>svgo": "3.3.3",
-      "tar": ">=7.5.8",
-      "axios": ">=1.13.5",
+      "tar": "^7.5.8",
+      "axios": "^1.13.5",
       "minimatch@<3.1.4": "3.1.4",
-      "rollup": ">=4.59.0",
-      "flatted": ">=3.4.0",
+      "rollup": "^4.59.0",
+      "flatted": "^3.4.0",
       "undici": "^6.24.0",
       "anymatch>picomatch": "2.3.2",
       "micromatch>picomatch": "2.3.2",
       "tinyglobby>picomatch": "4.0.4",
       "vite>picomatch": "4.0.4",
       "astro>picomatch": "4.0.4",
-      "lodash": ">=4.17.23",
-      "h3": ">=1.15.9",
-      "fast-xml-parser": ">=5.5.7",
-      "smol-toml": ">=1.6.1",
-      "yaml": ">=2.8.3"
+      "lodash": "^4.17.23",
+      "h3": "^1.15.9",
+      "fast-xml-parser": "^5.5.7",
+      "smol-toml": "^1.6.1",
+      "yaml": "^2.8.3"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,22 +7,22 @@ settings:
 overrides:
   astro>svgo: 4.0.1
   '@iconify/tools>svgo': 3.3.3
-  tar: '>=7.5.8'
-  axios: '>=1.13.5'
+  tar: ^7.5.8
+  axios: ^1.13.5
   minimatch@<3.1.4: 3.1.4
-  rollup: '>=4.59.0'
-  flatted: '>=3.4.0'
+  rollup: ^4.59.0
+  flatted: ^3.4.0
   undici: ^6.24.0
   anymatch>picomatch: 2.3.2
   micromatch>picomatch: 2.3.2
   tinyglobby>picomatch: 4.0.4
   vite>picomatch: 4.0.4
   astro>picomatch: 4.0.4
-  lodash: '>=4.17.23'
-  h3: '>=1.15.9'
-  fast-xml-parser: '>=5.5.7'
-  smol-toml: '>=1.6.1'
-  yaml: '>=2.8.3'
+  lodash: ^4.17.23
+  h3: ^1.15.9
+  fast-xml-parser: ^5.5.7
+  smol-toml: ^1.6.1
+  yaml: ^2.8.3
 
 importers:
 
@@ -939,7 +939,7 @@ packages:
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      rollup: '>=4.59.0'
+      rollup: ^4.59.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -3171,7 +3171,7 @@ packages:
       sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: '>=2.8.3'
+      yaml: ^2.8.3
     peerDependenciesMeta:
       '@types/node':
         optional: true


### PR DESCRIPTION
## Summary

- **Node 20 → 22 LTS 상향**: Node 20 EOL(2026-04-30) 임박. CI/Deploy 워크플로우 및 `package.json` engines 필드 모두 22로 이동.
- **GitHub Actions 메이저 업 5건 통합**: Dependabot PR #20~#24를 브랜치에 직접 병합(개별 PR close 대신 일괄 처리).
- **`dependabot.yml` 그룹핑 버그 수정**: `github_actions`에 `ci-actions` 그룹 정의 추가 → 향후 액션 업그레이드 분산 방지.
- **`pnpm.overrides` 상한 고정**: 9개 `>=` → `^`로 전환. 직전 undici 6→8 무단 승격으로 인한 Node 20 크래시(`077edfc`)와 같은 major 비호환 재발 차단.

## 변경 내역

### 워크플로우
| 파일 | 변경 |
|---|---|
| `.github/workflows/ci.yml` | `node-version: [22]`, checkout/setup-node/pnpm v6 |
| `.github/workflows/astro.yml` | `node-version: "22"`, checkout/setup-node/pnpm v6, upload-pages-artifact v5, deploy-pages v5 |
| `.github/workflows/claude.yml`, `claude-code-review.yml` | checkout v6 |

### 설정
| 파일 | 변경 |
|---|---|
| `.github/dependabot.yml` | github_actions에 `groups.ci-actions` 추가 |
| `package.json` | `engines.node: ">=22.0.0"`, pnpm.overrides 9개 `>=`→`^` |
| `pnpm-lock.yaml` | 재생성 |

## 묶음 C(미포함, 별도 PR)
Node 22 환경 위에서 개별 진행: #25 Astro 6+vite 7, #27 eslint 10, #28 TS 6 계열, #29 satori 0.26.

## Test plan

- [x] `pnpm audit` 0건
- [x] `pnpm lint` 통과
- [x] `pnpm build` 154 pages
- [x] `pnpm test` 32 passed (Playwright e2e)
- [ ] CI 워크플로우 통과 (Node 22 + 새 액션 태그)
- [ ] Deploy 워크플로우 통과 → GitHub Pages 실제 배포

Closes #20
Closes #21
Closes #22
Closes #23
Closes #24