### PR TITLE
feat(blog): 프레젠테이션 모드 버튼에 텍스트 라벨 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ test-results/
 
 # Claude Code local settings
 .claude/settings.local.json
+
+# git worktrees (superpowers:using-git-worktrees 스킬 생성 경로)
+.worktrees/

--- a/docs/superpowers/specs/2026-04-18-presentation-button-label-design.md
+++ b/docs/superpowers/specs/2026-04-18-presentation-button-label-design.md
@@ -1,0 +1,108 @@
+# 프레젠테이션 모드 버튼 텍스트 라벨 추가
+
+- **작성일**: 2026-04-18
+- **대상 파일**: `src/features/blog/components/PresentationModeButton.astro`
+- **유형**: UI 개선 (시각적 가시성 향상)
+
+## 배경
+
+포스트 상세 페이지(`PostDetails` 레이아웃, `PostMetadata` 컴포넌트)에는 프로젝터 아이콘(`ph:projector-screen`)만 표시되는 프레젠테이션 모드 트리거 버튼이 있다. 이 버튼은 런타임에 H2 ≥ 2개인 포스트에서만 `hidden = false`로 노출된다.
+
+현재는 아이콘 단독 노출이라 **기능이 무엇인지 시각적으로 식별하기 어렵다**. 호버 시 `title` 속성으로 "프레젠테이션 모드 (Shift+P)"가 보이지만, 호버 이전에는 발견 자체가 어렵다. 특히 같은 줄에 있던 `EditPost` 버튼이 현재 설정(`SITE.editPost.enabled`)상 비활성 상태라 이 버튼이 포스트 메타 영역의 유일한 액션 버튼으로 기능하므로, 가시성 확보가 더욱 중요하다.
+
+## 목표
+
+아이콘 옆에 `"프레젠테이션 모드"` 텍스트 라벨을 추가해 버튼의 기능을 즉시 식별 가능하게 한다.
+
+## 범위 (In Scope)
+
+- `PresentationModeButton.astro` 단일 파일에 `<span>프레젠테이션 모드</span>` 추가
+- 기존 동작(런타임 `hidden` 토글, 모바일 숨김, 단축키, 접근성 속성, 스타일)은 그대로 유지
+
+## 범위 외 (Out of Scope)
+
+- 단축키(`Shift+P`)의 시각적 노출 — 현재처럼 `title` 툴팁과 `aria-keyshortcuts`로만 유지
+- `EditPost` 버튼 스타일 변경 — 비활성 상태이므로 건드릴 필요 없음
+- 모바일에서의 버튼 노출 — 프레젠테이션 모드는 데스크탑 전용이라 `max-sm:hidden` 유지
+- 아이콘 교체나 컬러/사이즈 변경
+
+## 결정 사항
+
+### D1. 라벨 문구: `"프레젠테이션 모드"`
+
+- `aria-label="프레젠테이션 모드 시작"` 및 `title="프레젠테이션 모드 (Shift+P)"`와 일관된 표현
+- E2E 테스트(`e2e/presentation-mode.spec.ts`)의 `aria-label` 단언과 충돌 없음
+
+### D2. 단축키는 시각적으로 노출하지 않음
+
+- 주 목적은 "기능 식별 가능성 확보"이지 "단축키 홍보"가 아님
+- 단축키 정보는 `title` 툴팁으로 이미 제공 중
+
+### D3. 스타일은 현재 값 그대로 유지
+
+- 클래스: `flex items-center gap-1.5 p-2 opacity-80 transition-all duration-200 hover:text-accent max-sm:hidden sm:p-1`
+- 이유: 옆 `EditPost`가 비활성 상태라 스타일 통일 필요 없음. 기존 패딩/트랜지션은 터치/호버 UX에 기여하므로 유지.
+
+## 구현 변경점
+
+`src/features/blog/components/PresentationModeButton.astro`:
+
+```diff
+   <Icon name="ph:projector-screen" size={20} />
++  <span>프레젠테이션 모드</span>
+ </button>
+```
+
+전체 파일 예상 상태:
+
+```astro
+---
+import { Icon } from "astro-icon/components";
+---
+
+<!--
+  프레젠테이션 모드 트리거 버튼.
+  - 초기에는 `hidden` 속성으로 렌더되지만 비표시.
+  - src/features/blog/scripts/presentationMode.ts가 슬라이드 가능 여부(H2 ≥ 2개 등)를
+    런타임에 판정해 `button.hidden = false`로 노출한다.
+  - 모바일에서는 `max-sm:hidden`으로 완전히 숨김.
+-->
+<button
+  type="button"
+  data-button="presentation-start"
+  class="flex items-center gap-1.5 p-2 opacity-80 transition-all duration-200 hover:text-accent max-sm:hidden sm:p-1"
+  aria-label="프레젠테이션 모드 시작"
+  title="프레젠테이션 모드 (Shift+P)"
+  aria-keyshortcuts="Shift+P"
+  hidden
+>
+  <Icon name="ph:projector-screen" size={20} />
+  <span>프레젠테이션 모드</span>
+</button>
+```
+
+## 영향 분석
+
+| 영역 | 영향 여부 | 비고 |
+|------|----------|------|
+| `presentationMode.ts` 런타임 로직 | ❌ 없음 | `[data-button="presentation-start"]` 셀렉터 및 `.hidden` 토글만 사용 |
+| E2E 테스트 (`e2e/presentation-mode.spec.ts`) | ❌ 없음 | `data-button` attribute, `aria-label`, `aria-keyshortcuts`만 검증 |
+| 접근성 (SR 사용자) | ➖ 중립 | `aria-label`이 이미 완전한 문장이라 추가 `<span>`은 중복 낭독되지 않음 (label 우선) |
+| 모바일 | ❌ 없음 | `max-sm:hidden`으로 계속 숨김 |
+| 다크 모드 | ❌ 없음 | 텍스트 색상은 부모로부터 상속 (`hover:text-accent`가 이미 적용 중) |
+
+## 검증 방법
+
+1. **로컬 개발 서버**: `pnpm dev` → H2 ≥ 2개인 포스트(예: 번역 글) 접속 → 버튼에 "프레젠테이션 모드" 텍스트 노출 확인
+2. **빌드 산출물 검증** (CLAUDE.md 가이드라인): `pnpm build` → `dist/posts/<slug>/index.html`에서 버튼 렌더링 확인
+3. **E2E 테스트**: `pnpm test:e2e` (또는 해당 스크립트)로 `presentation-mode.spec.ts` 전체 통과 확인
+4. **H2가 부족한 포스트**: 버튼이 여전히 `hidden` 상태로 유지되는지 확인 (기존 동작 회귀 없음 검증)
+5. **모바일 뷰포트**: `max-sm` 이하 해상도에서 버튼이 보이지 않음 확인
+
+## 리스크 및 완화
+
+- **리스크**: 텍스트 추가로 버튼 너비가 커져 좁은 데스크탑 폭에서 메타 영역이 줄바꿈될 가능성
+- **완화**: 부모 컨테이너가 이미 `flex flex-wrap items-center gap-2`를 사용하므로 자연스럽게 다음 줄로 넘어감. 시각적 문제 없음.
+
+- **리스크**: 스크린 리더가 `aria-label`과 `<span>` 텍스트를 중복 낭독
+- **완화**: WAI-ARIA 사양상 `aria-label`이 있으면 내부 텍스트는 무시됨. 실제 중복 낭독 없음.

--- a/src/features/blog/components/PresentationModeButton.astro
+++ b/src/features/blog/components/PresentationModeButton.astro
@@ -19,4 +19,5 @@ import { Icon } from "astro-icon/components";
   hidden
 >
   <Icon name="ph:projector-screen" size={20} />
+  <span>프레젠테이션 모드</span>
 </button>


### PR DESCRIPTION
## Summary

- 포스트 상세 페이지의 프레젠테이션 모드 트리거 버튼에 `"프레젠테이션 모드"` 텍스트 라벨을 추가해 **아이콘만 있던 버튼의 시각적 식별성을 개선**합니다.
- `EditPost` 버튼이 현재 비활성 상태라 이 버튼이 포스트 메타 영역의 **유일한 액션 버튼**으로 기능하므로, 가시성 개선 효과가 큽니다.
- 함께 `.gitignore`에 `.worktrees/` 경로를 추가해 앞으로 격리 워크스페이스 사용 시 실수 커밋을 예방합니다.

## 변경점

### 1. `chore: .gitignore에 .worktrees/ 경로 추가` (feea571)
- `.worktrees/` 디렉토리가 git에 포함되지 않도록 예외 처리.

### 2. `feat(blog): 프레젠테이션 모드 버튼에 텍스트 라벨 추가` (c3a0110)
- `src/features/blog/components/PresentationModeButton.astro`: `<span>프레젠테이션 모드</span>` 1줄 추가
- `docs/superpowers/specs/2026-04-18-presentation-button-label-design.md`: 설계 문서 포함 (배경·결정·영향·리스크)

## 설계 결정 (요약)

| 항목 | 선택 | 이유 |
|---|---|---|
| 라벨 문구 | `"프레젠테이션 모드"` | `aria-label`/`title`과 동일해 일관성 확보, SR 중복 낭독 없음 |
| 단축키 시각 노출 | ❌ | 주 목적은 식별성이지 단축키 홍보가 아님. `title` 툴팁 유지 |
| 스타일 변경 | ❌ | `EditPost`가 비활성이라 통일 필요 없음. 기존 패딩/트랜지션이 UX에 기여 |
| 모바일 노출 | ❌ | `max-sm:hidden` 유지 (프레젠테이션 모드는 데스크탑 전용) |

## 영향 분석

| 영역 | 영향 | 비고 |
|---|---|---|
| `presentationMode.ts` 런타임 | 없음 | `data-button` 셀렉터만 사용 |
| E2E (`e2e/presentation-mode.spec.ts`) | 없음 | `data-button`, `aria-label`, `aria-keyshortcuts`만 검증 |
| 접근성 | 중립 | `aria-label` 우선이라 `<span>` 텍스트는 SR에서 무시됨 |

## Test plan

- [ ] `pnpm dev`로 H2 ≥ 2개인 포스트(예: `posts/translation/claude-skills-guide-part-4`) 접속 → "프레젠테이션 모드" 텍스트가 아이콘 옆에 노출되는지 확인
- [ ] `pnpm build` 성공 → `dist/posts/<slug>/index.html`에 `<span>프레젠테이션 모드</span>` 포함 확인
- [ ] H2 < 2개인 포스트에서 버튼이 여전히 `hidden`으로 유지되는지 회귀 확인
- [ ] 모바일 뷰포트(`max-sm`)에서 버튼이 보이지 않는지 확인
- [ ] `e2e/presentation-mode.spec.ts` 기존 E2E 스펙 전부 통과
- [ ] 버튼 클릭·`Shift+P`로 프레젠테이션 오버레이 진입 동작 확인