### PR TITLE
[codex] 프레젠테이션 모드 핵심 요약 슬라이드 분리

### DIFF
--- a/e2e/presentation-mode.spec.ts
+++ b/e2e/presentation-mode.spec.ts
@@ -3,6 +3,8 @@ import { test, expect, type Page } from "@playwright/test";
 // 목차(## 목차)가 있는 번역 포스트 - Agenda 슬라이드 검증 가능
 const TEST_POST_SLUG = "translation/claude-skills-guide-part-4";
 const TEST_POST_URL = `/posts/${TEST_POST_SLUG}`;
+const SUMMARY_SPLIT_POST_URL =
+  "/posts/translation/migrating-off-nextjs-tanstack-start";
 
 /**
  * 프레젠테이션 버튼이 런타임에 노출될 때까지 대기.
@@ -137,6 +139,45 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
     expect(sectionH2Texts).not.toContain("목차");
     expect(sectionH2Texts.map(t => t.toLowerCase())).not.toContain(
       "table of contents"
+    );
+  });
+
+  test("핵심 요약 뒤 도입 본문은 별도 슬라이드로 분리되어야 함", async ({
+    page,
+  }) => {
+    await page.goto(SUMMARY_SPLIT_POST_URL);
+    await waitForPresentationButton(page);
+    await page.locator('[data-button="presentation-start"]').click();
+
+    const summaryAndIntro = await page.evaluate(() => {
+      const sectionSlides = Array.from(
+        document.querySelectorAll<HTMLElement>(".presentation-slide-section")
+      );
+      const summaryIndex = sectionSlides.findIndex(
+        slide =>
+          slide.querySelector(":scope > h2")?.textContent?.trim() ===
+          "핵심 요약"
+      );
+      const summarySlide = sectionSlides[summaryIndex];
+      const introSlide = sectionSlides[summaryIndex + 1];
+
+      return {
+        summaryText: summarySlide?.textContent ?? "",
+        summaryDetailsOpen:
+          (summarySlide?.querySelector("details") as HTMLDetailsElement | null)
+            ?.open ?? false,
+        introHasHeading: introSlide?.querySelector(":scope > h2") !== null,
+        introText: introSlide?.textContent ?? "",
+      };
+    });
+
+    expect(summaryAndIntro.summaryText).toContain("주요 내용");
+    expect(summaryAndIntro.summaryDetailsOpen).toBe(true);
+    expect(summaryAndIntro.summaryText).not.toContain("Inngest에서 DX");
+    expect(summaryAndIntro.introHasHeading).toBe(false);
+    expect(summaryAndIntro.introText).toContain("Inngest에서 DX");
+    expect(summaryAndIntro.introText).toContain(
+      "이 글은 우리가 Next.js에서 벗어난 과정"
     );
   });
 

--- a/e2e/presentation-mode.spec.ts
+++ b/e2e/presentation-mode.spec.ts
@@ -8,7 +8,8 @@ const TEST_POST_URL = `/posts/${TEST_POST_SLUG}`;
 // 슬러그나 문서 구조가 바뀌면 이 테스트도 함께 갱신해야 한다.
 const SUMMARY_SPLIT_POST_URL =
   "/posts/translation/migrating-off-nextjs-tanstack-start";
-// 구조 기반 assertion에서 우연히 짧은 텍스트 조각이 겹치는 false positive를 줄이는 가드.
+// 실제 포스트를 쓰는 구조 기반 assertion에서 false positive를 줄이는 낮은 임계값.
+// 대상 포스트의 도입 본문은 이 값보다 충분히 길어, 구조가 바뀌면 선명하게 실패한다.
 const MIN_INTRO_TEXT_LENGTH = 50;
 const MIN_INTRO_BLOCK_TEXT_LENGTH = 20;
 

--- a/e2e/presentation-mode.spec.ts
+++ b/e2e/presentation-mode.spec.ts
@@ -12,6 +12,8 @@ const SUMMARY_SPLIT_POST_URL =
 // 대상 포스트의 도입 본문은 이 값보다 충분히 길어, 구조가 바뀌면 선명하게 실패한다.
 const MIN_INTRO_TEXT_LENGTH = 50;
 const MIN_INTRO_BLOCK_TEXT_LENGTH = 20;
+const SUMMARY_SPLIT_STRUCTURE_HINT =
+  "SUMMARY_SPLIT_POST_URL의 핵심 요약/details/hr/도입 구조가 바뀌었는지 확인하세요.";
 
 /**
  * 프레젠테이션 버튼이 런타임에 노출될 때까지 대기.
@@ -185,15 +187,20 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
       };
     });
 
-    expect(summaryAndIntro.summaryIndex).toBeGreaterThanOrEqual(0);
+    expect(
+      summaryAndIntro.summaryIndex,
+      SUMMARY_SPLIT_STRUCTURE_HINT
+    ).toBeGreaterThanOrEqual(0);
     expect(summaryAndIntro.summaryDetailsOpen).toBe(true);
     expect(summaryAndIntro.introHasHeading).toBe(false);
-    expect(summaryAndIntro.introText.length).toBeGreaterThan(
-      MIN_INTRO_TEXT_LENGTH
-    );
-    expect(summaryAndIntro.introFirstBlockText.length).toBeGreaterThan(
-      MIN_INTRO_BLOCK_TEXT_LENGTH
-    );
+    expect(
+      summaryAndIntro.introText.length,
+      SUMMARY_SPLIT_STRUCTURE_HINT
+    ).toBeGreaterThan(MIN_INTRO_TEXT_LENGTH);
+    expect(
+      summaryAndIntro.introFirstBlockText.length,
+      SUMMARY_SPLIT_STRUCTURE_HINT
+    ).toBeGreaterThan(MIN_INTRO_BLOCK_TEXT_LENGTH);
     expect(summaryAndIntro.summaryText).not.toContain(
       summaryAndIntro.introFirstBlockText
     );
@@ -222,10 +229,25 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
       );
       if (!summary) return false;
 
-      summary.textContent = "요약 보기";
-      return true;
+      const walker = document.createTreeWalker(summary, NodeFilter.SHOW_TEXT);
+      let fallbackTextNode: Text | null = null;
+      let currentNode = walker.nextNode() as Text | null;
+      while (currentNode) {
+        if (currentNode.textContent?.trim()) {
+          fallbackTextNode ??= currentNode;
+          if (currentNode.textContent.includes("TL;DR")) {
+            currentNode.textContent = "요약 보기";
+            return !summary.textContent?.includes("TL;DR");
+          }
+        }
+        currentNode = walker.nextNode() as Text | null;
+      }
+
+      if (!fallbackTextNode) return false;
+      fallbackTextNode.textContent = "요약 보기";
+      return !summary.textContent?.includes("TL;DR");
     });
-    expect(mutated).toBe(true);
+    expect(mutated, SUMMARY_SPLIT_STRUCTURE_HINT).toBe(true);
 
     await page.locator('[data-button="presentation-start"]').click();
 
@@ -248,7 +270,10 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
       };
     });
 
-    expect(summaryDetailsState.summaryIndex).toBeGreaterThanOrEqual(0);
+    expect(
+      summaryDetailsState.summaryIndex,
+      SUMMARY_SPLIT_STRUCTURE_HINT
+    ).toBeGreaterThanOrEqual(0);
     expect(summaryDetailsState.summaryDetailsOpen).toBe(false);
   });
 
@@ -295,7 +320,7 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
 
       return true;
     });
-    expect(mutated).toBe(true);
+    expect(mutated, SUMMARY_SPLIT_STRUCTURE_HINT).toBe(true);
 
     await page.locator('[data-button="presentation-start"]').click();
 

--- a/e2e/presentation-mode.spec.ts
+++ b/e2e/presentation-mode.spec.ts
@@ -202,9 +202,9 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
     await page.goto(SUMMARY_SPLIT_POST_URL);
     await waitForPresentationButton(page);
 
-    await page.evaluate(() => {
+    const mutated = await page.evaluate(() => {
       const article = document.getElementById("article");
-      if (!article) return;
+      if (!article) return false;
 
       const getHeadingText = (heading: HTMLHeadingElement) => {
         const clone = heading.cloneNode(true) as HTMLElement;
@@ -214,7 +214,7 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
       const summaryHeading = Array.from(
         article.querySelectorAll<HTMLHeadingElement>(":scope > h2")
       ).find(h2 => getHeadingText(h2) === "핵심 요약");
-      if (!summaryHeading) return;
+      if (!summaryHeading) return false;
 
       let separator: Element | null = null;
       let sibling = summaryHeading.nextElementSibling;
@@ -225,7 +225,7 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
         }
         sibling = sibling.nextElementSibling;
       }
-      if (!separator) return;
+      if (!separator) return false;
 
       const emptyParagraph = document.createElement("p");
       separator.after(emptyParagraph);
@@ -236,7 +236,10 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
         introSibling.remove();
         introSibling = nextSibling;
       }
+
+      return true;
     });
+    expect(mutated).toBe(true);
 
     await page.locator('[data-button="presentation-start"]').click();
 

--- a/e2e/presentation-mode.spec.ts
+++ b/e2e/presentation-mode.spec.ts
@@ -3,6 +3,9 @@ import { test, expect, type Page } from "@playwright/test";
 // 목차(## 목차)가 있는 번역 포스트 - Agenda 슬라이드 검증 가능
 const TEST_POST_SLUG = "translation/claude-skills-guide-part-4";
 const TEST_POST_URL = `/posts/${TEST_POST_SLUG}`;
+// 핵심 요약 → details → hr → 도입 본문 패턴을 가진 실제 번역 포스트.
+// 별도 fixture를 콘텐츠 컬렉션에 넣지 않기 위해 이 URL을 사용하므로,
+// 슬러그나 문서 구조가 바뀌면 이 테스트도 함께 갱신해야 한다.
 const SUMMARY_SPLIT_POST_URL =
   "/posts/translation/migrating-off-nextjs-tanstack-start";
 
@@ -168,16 +171,87 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
             ?.open ?? false,
         introHasHeading: introSlide?.querySelector(":scope > h2") !== null,
         introText: introSlide?.textContent?.trim() ?? "",
+        introFirstBlockText:
+          introSlide
+            ?.querySelector(
+              ":scope > p, :scope > blockquote, :scope > ul, :scope > ol, :scope > pre, :scope > details, :scope > figure"
+            )
+            ?.textContent?.trim() ?? "",
       };
     });
 
     expect(summaryAndIntro.summaryText).toContain("주요 내용");
     expect(summaryAndIntro.summaryDetailsOpen).toBe(true);
     expect(summaryAndIntro.introHasHeading).toBe(false);
-    expect(summaryAndIntro.introText.length).toBeGreaterThan(0);
+    expect(summaryAndIntro.introText.length).toBeGreaterThan(50);
+    expect(summaryAndIntro.introFirstBlockText.length).toBeGreaterThan(20);
     expect(summaryAndIntro.summaryText).not.toContain(
-      summaryAndIntro.introText
+      summaryAndIntro.introFirstBlockText
     );
+  });
+
+  test("일반 H2 섹션은 제목 없는 슬라이드로 분리되지 않아야 함", async ({
+    page,
+  }) => {
+    await page.goto(TEST_POST_URL);
+    await waitForPresentationButton(page);
+
+    const ordinaryHeadingPair = await page.evaluate(() => {
+      const article = document.getElementById("article");
+      const getHeadingText = (heading: HTMLHeadingElement) => {
+        const clone = heading.cloneNode(true) as HTMLElement;
+        clone.querySelectorAll(".heading-link").forEach(el => el.remove());
+        return clone.textContent?.trim() ?? "";
+      };
+      const headings = Array.from(
+        article?.querySelectorAll<HTMLHeadingElement>(":scope > h2") ?? []
+      ).map(getHeadingText);
+      const headingIndex = headings.findIndex(
+        (text, index) =>
+          text !== "목차" && text !== "핵심 요약" && index < headings.length - 1
+      );
+
+      return headingIndex === -1
+        ? null
+        : {
+            heading: headings[headingIndex],
+            nextHeading: headings[headingIndex + 1],
+          };
+    });
+
+    expect(ordinaryHeadingPair).not.toBeNull();
+
+    await page.locator('[data-button="presentation-start"]').click();
+
+    const ordinarySlide = await page.evaluate(headingPair => {
+      if (!headingPair) return null;
+
+      const sectionSlides = Array.from(
+        document.querySelectorAll<HTMLElement>(".presentation-slide-section")
+      );
+      const targetIndex = sectionSlides.findIndex(
+        slide =>
+          slide.querySelector(":scope > h2")?.textContent?.trim() ===
+          headingPair.heading
+      );
+      const targetSlide = sectionSlides[targetIndex];
+      const nextSlide = sectionSlides[targetIndex + 1];
+
+      return {
+        targetIndex,
+        targetTextLength: targetSlide?.textContent?.trim().length ?? 0,
+        nextHeading:
+          nextSlide?.querySelector(":scope > h2")?.textContent?.trim() ?? null,
+        nextIsTitleless:
+          nextSlide !== undefined &&
+          nextSlide.querySelector(":scope > h2") === null,
+      };
+    }, ordinaryHeadingPair);
+
+    expect(ordinarySlide?.targetIndex).toBeGreaterThanOrEqual(0);
+    expect(ordinarySlide?.targetTextLength).toBeGreaterThan(50);
+    expect(ordinarySlide?.nextHeading).toBe(ordinaryHeadingPair!.nextHeading);
+    expect(ordinarySlide?.nextIsTitleless).toBe(false);
   });
 
   test("총 슬라이드가 MIN_SLIDES 미만이면 버튼을 눌러도 오버레이가 열리지 않아야 함", async ({

--- a/e2e/presentation-mode.spec.ts
+++ b/e2e/presentation-mode.spec.ts
@@ -168,6 +168,7 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
       const introSlide = sectionSlides[summaryIndex + 1];
 
       return {
+        summaryIndex,
         summaryText: summarySlide?.textContent ?? "",
         summaryDetailsOpen:
           (summarySlide?.querySelector("details") as HTMLDetailsElement | null)
@@ -183,6 +184,7 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
       };
     });
 
+    expect(summaryAndIntro.summaryIndex).toBeGreaterThanOrEqual(0);
     expect(summaryAndIntro.summaryDetailsOpen).toBe(true);
     expect(summaryAndIntro.introHasHeading).toBe(false);
     expect(summaryAndIntro.introText.length).toBeGreaterThan(
@@ -194,6 +196,59 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
     expect(summaryAndIntro.summaryText).not.toContain(
       summaryAndIntro.introFirstBlockText
     );
+  });
+
+  test("핵심 요약 details가 TL;DR이 아니면 기본으로 열지 않아야 함", async ({
+    page,
+  }) => {
+    await page.goto(SUMMARY_SPLIT_POST_URL);
+    await waitForPresentationButton(page);
+
+    const mutated = await page.evaluate(() => {
+      const article = document.getElementById("article");
+      if (!article) return false;
+
+      const getHeadingText = (heading: HTMLHeadingElement) => {
+        const clone = heading.cloneNode(true) as HTMLElement;
+        clone.querySelectorAll(".heading-link").forEach(el => el.remove());
+        return clone.textContent?.trim() ?? "";
+      };
+      const summaryHeading = Array.from(
+        article.querySelectorAll<HTMLHeadingElement>(":scope > h2")
+      ).find(h2 => getHeadingText(h2) === "핵심 요약");
+      const summary = summaryHeading?.nextElementSibling?.querySelector(
+        ":scope > summary"
+      );
+      if (!summary) return false;
+
+      summary.textContent = "요약 보기";
+      return true;
+    });
+    expect(mutated).toBe(true);
+
+    await page.locator('[data-button="presentation-start"]').click();
+
+    const summaryDetailsState = await page.evaluate(() => {
+      const sectionSlides = Array.from(
+        document.querySelectorAll<HTMLElement>(".presentation-slide-section")
+      );
+      const summaryIndex = sectionSlides.findIndex(
+        slide =>
+          slide.querySelector(":scope > h2")?.textContent?.trim() ===
+          "핵심 요약"
+      );
+      const summarySlide = sectionSlides[summaryIndex];
+
+      return {
+        summaryIndex,
+        summaryDetailsOpen:
+          (summarySlide?.querySelector("details") as HTMLDetailsElement | null)
+            ?.open ?? false,
+      };
+    });
+
+    expect(summaryDetailsState.summaryIndex).toBeGreaterThanOrEqual(0);
+    expect(summaryDetailsState.summaryDetailsOpen).toBe(false);
   });
 
   test("핵심 요약 뒤 실질 도입 본문이 없으면 제목 없는 슬라이드를 만들지 않아야 함", async ({

--- a/e2e/presentation-mode.spec.ts
+++ b/e2e/presentation-mode.spec.ts
@@ -8,6 +8,9 @@ const TEST_POST_URL = `/posts/${TEST_POST_SLUG}`;
 // 슬러그나 문서 구조가 바뀌면 이 테스트도 함께 갱신해야 한다.
 const SUMMARY_SPLIT_POST_URL =
   "/posts/translation/migrating-off-nextjs-tanstack-start";
+// 구조 기반 assertion에서 우연히 짧은 텍스트 조각이 겹치는 false positive를 줄이는 가드.
+const MIN_INTRO_TEXT_LENGTH = 50;
+const MIN_INTRO_BLOCK_TEXT_LENGTH = 20;
 
 /**
  * 프레젠테이션 버튼이 런타임에 노출될 때까지 대기.
@@ -180,14 +183,85 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
       };
     });
 
-    expect(summaryAndIntro.summaryText).toContain("주요 내용");
     expect(summaryAndIntro.summaryDetailsOpen).toBe(true);
     expect(summaryAndIntro.introHasHeading).toBe(false);
-    expect(summaryAndIntro.introText.length).toBeGreaterThan(50);
-    expect(summaryAndIntro.introFirstBlockText.length).toBeGreaterThan(20);
+    expect(summaryAndIntro.introText.length).toBeGreaterThan(
+      MIN_INTRO_TEXT_LENGTH
+    );
+    expect(summaryAndIntro.introFirstBlockText.length).toBeGreaterThan(
+      MIN_INTRO_BLOCK_TEXT_LENGTH
+    );
     expect(summaryAndIntro.summaryText).not.toContain(
       summaryAndIntro.introFirstBlockText
     );
+  });
+
+  test("핵심 요약 뒤 실질 도입 본문이 없으면 제목 없는 슬라이드를 만들지 않아야 함", async ({
+    page,
+  }) => {
+    await page.goto(SUMMARY_SPLIT_POST_URL);
+    await waitForPresentationButton(page);
+
+    await page.evaluate(() => {
+      const article = document.getElementById("article");
+      if (!article) return;
+
+      const getHeadingText = (heading: HTMLHeadingElement) => {
+        const clone = heading.cloneNode(true) as HTMLElement;
+        clone.querySelectorAll(".heading-link").forEach(el => el.remove());
+        return clone.textContent?.trim() ?? "";
+      };
+      const summaryHeading = Array.from(
+        article.querySelectorAll<HTMLHeadingElement>(":scope > h2")
+      ).find(h2 => getHeadingText(h2) === "핵심 요약");
+      if (!summaryHeading) return;
+
+      let separator: Element | null = null;
+      let sibling = summaryHeading.nextElementSibling;
+      while (sibling && sibling.tagName !== "H2") {
+        if (sibling.tagName === "HR") {
+          separator = sibling;
+          break;
+        }
+        sibling = sibling.nextElementSibling;
+      }
+      if (!separator) return;
+
+      const emptyParagraph = document.createElement("p");
+      separator.after(emptyParagraph);
+
+      let introSibling = emptyParagraph.nextElementSibling;
+      while (introSibling && introSibling.tagName !== "H2") {
+        const nextSibling = introSibling.nextElementSibling;
+        introSibling.remove();
+        introSibling = nextSibling;
+      }
+    });
+
+    await page.locator('[data-button="presentation-start"]').click();
+
+    const slideAfterSummary = await page.evaluate(() => {
+      const sectionSlides = Array.from(
+        document.querySelectorAll<HTMLElement>(".presentation-slide-section")
+      );
+      const summaryIndex = sectionSlides.findIndex(
+        slide =>
+          slide.querySelector(":scope > h2")?.textContent?.trim() ===
+          "핵심 요약"
+      );
+      const nextSlide = sectionSlides[summaryIndex + 1];
+
+      return {
+        nextHeading:
+          nextSlide?.querySelector(":scope > h2")?.textContent?.trim() ?? null,
+        nextIsTitleless:
+          nextSlide !== undefined &&
+          nextSlide.querySelector(":scope > h2") === null,
+      };
+    });
+
+    expect(slideAfterSummary.nextIsTitleless).toBe(false);
+    expect(slideAfterSummary.nextHeading).not.toBeNull();
   });
 
   test("일반 H2 섹션은 제목 없는 슬라이드로 분리되지 않아야 함", async ({

--- a/e2e/presentation-mode.spec.ts
+++ b/e2e/presentation-mode.spec.ts
@@ -167,17 +167,16 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
           (summarySlide?.querySelector("details") as HTMLDetailsElement | null)
             ?.open ?? false,
         introHasHeading: introSlide?.querySelector(":scope > h2") !== null,
-        introText: introSlide?.textContent ?? "",
+        introText: introSlide?.textContent?.trim() ?? "",
       };
     });
 
     expect(summaryAndIntro.summaryText).toContain("주요 내용");
     expect(summaryAndIntro.summaryDetailsOpen).toBe(true);
-    expect(summaryAndIntro.summaryText).not.toContain("Inngest에서 DX");
     expect(summaryAndIntro.introHasHeading).toBe(false);
-    expect(summaryAndIntro.introText).toContain("Inngest에서 DX");
-    expect(summaryAndIntro.introText).toContain(
-      "이 글은 우리가 Next.js에서 벗어난 과정"
+    expect(summaryAndIntro.introText.length).toBeGreaterThan(0);
+    expect(summaryAndIntro.summaryText).not.toContain(
+      summaryAndIntro.introText
     );
   });
 

--- a/e2e/presentation-mode.spec.ts
+++ b/e2e/presentation-mode.spec.ts
@@ -252,9 +252,12 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
           slide.querySelector(":scope > h2")?.textContent?.trim() ===
           "핵심 요약"
       );
+      const summarySlide = sectionSlides[summaryIndex];
       const nextSlide = sectionSlides[summaryIndex + 1];
 
       return {
+        summaryHasDirectHr:
+          summarySlide?.querySelector(":scope > hr") !== null,
         nextHeading:
           nextSlide?.querySelector(":scope > h2")?.textContent?.trim() ?? null,
         nextIsTitleless:
@@ -263,6 +266,7 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
       };
     });
 
+    expect(slideAfterSummary.summaryHasDirectHr).toBe(false);
     expect(slideAfterSummary.nextIsTitleless).toBe(false);
     expect(slideAfterSummary.nextHeading).not.toBeNull();
   });

--- a/e2e/presentation-mode.spec.ts
+++ b/e2e/presentation-mode.spec.ts
@@ -206,6 +206,74 @@ test.describe("프레젠테이션 모드 - 기본 동작", () => {
     );
   });
 
+  test("제목 없는 도입 슬라이드에서 닫으면 핵심 요약 H2로 스크롤 복귀해야 함", async ({
+    page,
+  }) => {
+    await page.goto(SUMMARY_SPLIT_POST_URL);
+    await waitForPresentationButton(page);
+
+    await page.evaluate(() => {
+      const win = window as unknown as Window & {
+        __presentationScrollTargets: string[];
+      };
+      win.__presentationScrollTargets = [];
+      const originalScrollIntoView = Element.prototype.scrollIntoView;
+      Element.prototype.scrollIntoView = function (
+        this: Element,
+        arg?: boolean | ScrollIntoViewOptions
+      ) {
+        const clone = this.cloneNode(true) as HTMLElement;
+        clone.querySelectorAll(".heading-link").forEach(el => el.remove());
+        win.__presentationScrollTargets.push(clone.textContent?.trim() ?? "");
+        originalScrollIntoView.call(this, arg);
+      };
+    });
+
+    await page.locator('[data-button="presentation-start"]').click();
+
+    const introSlideIndex = await page.evaluate(() => {
+      const slides = Array.from(
+        document.querySelectorAll<HTMLElement>(".presentation-slide")
+      );
+      const summaryIndex = slides.findIndex(
+        slide =>
+          slide.classList.contains("presentation-slide-section") &&
+          slide.querySelector(":scope > h2")?.textContent?.trim() ===
+            "핵심 요약"
+      );
+      const introSlide = slides[summaryIndex + 1];
+      if (!introSlide) return -1;
+      return introSlide.querySelector(":scope > h2") === null
+        ? summaryIndex + 1
+        : -1;
+    });
+
+    expect(introSlideIndex, SUMMARY_SPLIT_STRUCTURE_HINT).toBeGreaterThan(0);
+
+    for (let i = 0; i < introSlideIndex; i += 1) {
+      await page.keyboard.press("ArrowRight");
+    }
+    await expect(page.locator(".presentation-counter")).toHaveText(
+      new RegExp(`^${introSlideIndex + 1} /`)
+    );
+
+    await page.keyboard.press("Escape");
+    await page.waitForFunction(() => {
+      const win = window as unknown as Window & {
+        __presentationScrollTargets?: string[];
+      };
+      return (win.__presentationScrollTargets?.length ?? 0) > 0;
+    });
+
+    const lastScrollTarget = await page.evaluate(() => {
+      const win = window as unknown as Window & {
+        __presentationScrollTargets?: string[];
+      };
+      return win.__presentationScrollTargets?.at(-1) ?? null;
+    });
+    expect(lastScrollTarget).toBe("핵심 요약");
+  });
+
   test("핵심 요약 details가 TL;DR이 아니면 기본으로 열지 않아야 함", async ({
     page,
   }) => {

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -25,6 +25,7 @@ const AGENDA_SUMMARY_TEXT = "목차 보기";
 const AGENDA_H2_PATTERN = /^(table of contents|목차)$/i;
 // 정확히 "핵심 요약"인 H2만 분리 대상으로 삼는다. 이모지나 부제목이 붙으면 일반 섹션으로 둔다.
 const SUMMARY_H2_PATTERN = /^핵심 요약$/;
+const TLDR_SUMMARY_PATTERN = /TL;DR/i;
 const MIN_SLIDES = 2;
 
 interface PresentationState {
@@ -436,7 +437,8 @@ function buildAgendaSlide(sourceDetails: HTMLDetailsElement): HTMLElement {
 /**
  * H2 섹션 슬라이드들: 기본적으로 해당 h2와 "다음 h2 직전까지의 형제 노드"를 복제.
  * 번역 글의 `핵심 요약 → details → hr → 도입 본문` 패턴은 원문 구조를 바꾸지 않고
- * 프레젠테이션 전용 제목 없는 슬라이드로 분리한다.
+ * 프레젠테이션 전용 제목 없는 슬라이드로 분리한다. 도입 본문이 비어 있으면 구분선 뒤를
+ * 버리고 요약 슬라이드만 만든다.
  */
 function buildSectionSlides(h2: HTMLHeadingElement): HTMLElement[] {
   const summaryIntroSplit = findSummaryIntroSplit(h2);
@@ -444,18 +446,22 @@ function buildSectionSlides(h2: HTMLHeadingElement): HTMLElement[] {
     return [buildSectionSlide(h2)];
   }
 
-  const introSlide = buildSyntheticSectionSlide(
-    summaryIntroSplit.firstIntroElement
-  );
-  if (!introSlide) {
-    return [buildSectionSlide(h2)];
-  }
-
   // separator(hr)는 요약과 도입을 나누는 경계일 뿐, 요약 슬라이드에는 포함하지 않는다.
   const summarySlide = buildSectionSlide(h2, {
     stopBefore: summaryIntroSplit.separator,
   });
-  openFirstDetails(summarySlide);
+  openSummaryDetails(summarySlide);
+
+  if (!summaryIntroSplit.firstIntroElement) {
+    return [summarySlide];
+  }
+
+  const introSlide = buildSyntheticSectionSlide(
+    summaryIntroSplit.firstIntroElement
+  );
+  if (!introSlide) {
+    return [summarySlide];
+  }
 
   return [summarySlide, introSlide];
 }
@@ -483,8 +489,8 @@ function buildSectionSlide(
 }
 
 /**
- * 제목 없는 도입 본문 슬라이드. 실질 콘텐츠가 없으면 기존 단일 H2 슬라이드로
- * 폴백할 수 있도록 null을 반환한다.
+ * 제목 없는 도입 본문 슬라이드. 실질 콘텐츠가 없으면 호출부에서 도입 슬라이드를
+ * 생략할 수 있도록 null을 반환한다.
  */
 function buildSyntheticSectionSlide(startElement: Element): HTMLElement | null {
   const slide = document.createElement("section");
@@ -525,15 +531,22 @@ function appendSiblingClones(
   return hasContent;
 }
 
-function openFirstDetails(slide: HTMLElement): void {
-  // 핵심 요약 슬라이드의 첫 details가 TL;DR이라는 현재 번역 글 구조를 전제로 한다.
-  const details = slide.querySelector<HTMLDetailsElement>("details");
+function openSummaryDetails(slide: HTMLElement): void {
+  const detailsElements = Array.from(
+    slide.querySelectorAll<HTMLDetailsElement>(":scope > details")
+  );
+  const details =
+    detailsElements.find(details =>
+      TLDR_SUMMARY_PATTERN.test(
+        details.querySelector(":scope > summary")?.textContent ?? ""
+      )
+    ) ?? detailsElements[0];
   if (details) details.open = true;
 }
 
 function findSummaryIntroSplit(
   h2: HTMLHeadingElement
-): { separator: Element; firstIntroElement: Element } | null {
+): { separator: Element; firstIntroElement: Element | null } | null {
   if (!SUMMARY_H2_PATTERN.test(getHeadingText(h2))) return null;
 
   // details 요소 자체가 아니라, 이후 등장하는 hr을 분리 경계로 인정하기 위한 상태만 추적한다.
@@ -554,10 +567,7 @@ function findSummaryIntroSplit(
       const firstIntroElement = findFirstIntroElement(
         sibling.nextElementSibling
       );
-      if (firstIntroElement) {
-        return { separator: sibling, firstIntroElement };
-      }
-      return null;
+      return { separator: sibling, firstIntroElement };
     }
 
     sibling = sibling.nextElementSibling;

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -23,6 +23,7 @@ const AGENDA_SUMMARY_TEXT = "목차 보기";
  * astro.config.ts의 remark-collapse `test` 정규식과 의미 일치.
  */
 const AGENDA_H2_PATTERN = /^(table of contents|목차)$/i;
+const SUMMARY_H2_PATTERN = /^핵심 요약$/i;
 const MIN_SLIDES = 2;
 
 interface PresentationState {
@@ -349,7 +350,7 @@ function buildSlides(): HTMLElement[] {
     article.querySelectorAll<HTMLHeadingElement>(":scope > h2")
   ).filter(h2 => !AGENDA_H2_PATTERN.test(getHeadingText(h2)));
   for (const h2 of h2s) {
-    slides.push(buildSectionSlide(h2));
+    slides.push(...buildSectionSlides(h2));
   }
 
   return slides;
@@ -432,9 +433,34 @@ function buildAgendaSlide(sourceDetails: HTMLDetailsElement): HTMLElement {
 }
 
 /**
+ * H2 섹션 슬라이드들: 기본적으로 해당 h2와 "다음 h2 직전까지의 형제 노드"를 복제.
+ * 번역 글의 `핵심 요약 → details → hr → 도입 본문` 패턴은 원문 구조를 바꾸지 않고
+ * 프레젠테이션 전용 제목 없는 슬라이드로 분리한다.
+ */
+function buildSectionSlides(h2: HTMLHeadingElement): HTMLElement[] {
+  const summaryIntroSplit = findSummaryIntroSplit(h2);
+  if (!summaryIntroSplit) {
+    return [buildSectionSlide(h2)];
+  }
+
+  const summarySlide = buildSectionSlide(h2, {
+    stopBefore: summaryIntroSplit.separator,
+  });
+  openDetails(summarySlide);
+  const introSlide = buildSyntheticSectionSlide(
+    summaryIntroSplit.firstIntroElement
+  );
+
+  return introSlide ? [summarySlide, introSlide] : [buildSectionSlide(h2)];
+}
+
+/**
  * H2 섹션 슬라이드: 해당 h2와 "다음 h2 직전까지의 형제 노드"를 복제.
  */
-function buildSectionSlide(h2: HTMLHeadingElement): HTMLElement {
+function buildSectionSlide(
+  h2: HTMLHeadingElement,
+  options: { stopBefore?: Element } = {}
+): HTMLElement {
   const slide = document.createElement("section");
   slide.className = "presentation-slide presentation-slide-section";
 
@@ -444,7 +470,11 @@ function buildSectionSlide(h2: HTMLHeadingElement): HTMLElement {
 
   // 형제 노드 순회: 다음 h2를 만나기 전까지 복제
   let sibling = h2.nextElementSibling;
-  while (sibling && sibling.tagName !== "H2") {
+  while (
+    sibling &&
+    sibling.tagName !== "H2" &&
+    sibling !== options.stopBefore
+  ) {
     // 목차 블록은 이미 별도 슬라이드로 처리되므로 제외
     if (isAgendaBlock(sibling)) {
       sibling = sibling.nextElementSibling;
@@ -457,6 +487,80 @@ function buildSectionSlide(h2: HTMLHeadingElement): HTMLElement {
 
   sanitizeSlide(slide);
   return slide;
+}
+
+function buildSyntheticSectionSlide(startElement: Element): HTMLElement | null {
+  const slide = document.createElement("section");
+  slide.className = "presentation-slide presentation-slide-section";
+
+  let hasContent = false;
+  let sibling: Element | null = startElement;
+  while (sibling && sibling.tagName !== "H2") {
+    if (isAgendaBlock(sibling)) {
+      sibling = sibling.nextElementSibling;
+      continue;
+    }
+
+    const clone = sibling.cloneNode(true) as Element;
+    slide.appendChild(clone);
+    hasContent = true;
+    sibling = sibling.nextElementSibling;
+  }
+
+  if (!hasContent) return null;
+
+  sanitizeSlide(slide);
+  return slide;
+}
+
+function openDetails(slide: HTMLElement): void {
+  slide.querySelectorAll<HTMLDetailsElement>("details").forEach(details => {
+    details.open = true;
+  });
+}
+
+function findSummaryIntroSplit(
+  h2: HTMLHeadingElement
+): { separator: Element; firstIntroElement: Element } | null {
+  if (!SUMMARY_H2_PATTERN.test(getHeadingText(h2))) return null;
+
+  let sawDetails = false;
+  let sibling = h2.nextElementSibling;
+  while (sibling && sibling.tagName !== "H2") {
+    if (isAgendaBlock(sibling)) {
+      sibling = sibling.nextElementSibling;
+      continue;
+    }
+
+    if (sibling.tagName === "DETAILS") {
+      sawDetails = true;
+    }
+
+    if (sawDetails && sibling.tagName === "HR") {
+      const firstIntroElement = findFirstIntroElement(
+        sibling.nextElementSibling
+      );
+      if (firstIntroElement) {
+        return { separator: sibling, firstIntroElement };
+      }
+      return null;
+    }
+
+    sibling = sibling.nextElementSibling;
+  }
+
+  return null;
+}
+
+function findFirstIntroElement(startElement: Element | null): Element | null {
+  let sibling = startElement;
+  while (sibling && sibling.tagName !== "H2") {
+    if (sibling.tagName !== "HR" && !isAgendaBlock(sibling)) {
+      return sibling;
+    }
+    sibling = sibling.nextElementSibling;
+  }
+  return null;
 }
 
 /**

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -443,11 +443,11 @@ function buildAgendaSlide(sourceDetails: HTMLDetailsElement): HTMLElement {
 function buildSectionSlides(h2: HTMLHeadingElement): HTMLElement[] {
   const summaryIntroSplit = findSummaryIntroSplit(h2);
   if (!summaryIntroSplit) {
-    return [buildSectionSlide(h2)];
+    return [buildSingleSectionSlide(h2)];
   }
 
   // separator(hr)는 요약과 도입을 나누는 경계일 뿐, 요약 슬라이드에는 포함하지 않는다.
-  const summarySlide = buildSectionSlide(h2, {
+  const summarySlide = buildSingleSectionSlide(h2, {
     stopBefore: summaryIntroSplit.separator,
   });
   openSummaryDetails(summarySlide);
@@ -469,7 +469,7 @@ function buildSectionSlides(h2: HTMLHeadingElement): HTMLElement[] {
 /**
  * H2 섹션 슬라이드: 해당 h2와 "다음 h2 직전까지의 형제 노드"를 복제.
  */
-function buildSectionSlide(
+function buildSingleSectionSlide(
   h2: HTMLHeadingElement,
   options: { stopBefore?: Element } = {}
 ): HTMLElement {
@@ -535,6 +535,10 @@ function appendSiblingClones(
   return hasContent;
 }
 
+/**
+ * 핵심 요약 슬라이드의 직계 details 중 TL;DR summary와 일치하는 항목만 펼친다.
+ * 중첩 details는 현재 번역 글 구조의 핵심 요약 대상이 아니므로 건드리지 않는다.
+ */
 function openSummaryDetails(slide: HTMLElement): void {
   const detailsElements = Array.from(
     slide.querySelectorAll<HTMLDetailsElement>(":scope > details")

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -482,6 +482,10 @@ function buildSectionSlide(
   return slide;
 }
 
+/**
+ * 제목 없는 도입 본문 슬라이드. 실질 콘텐츠가 없으면 기존 단일 H2 슬라이드로
+ * 폴백할 수 있도록 null을 반환한다.
+ */
 function buildSyntheticSectionSlide(startElement: Element): HTMLElement | null {
   const slide = document.createElement("section");
   slide.className = "presentation-slide presentation-slide-section";
@@ -501,6 +505,7 @@ function appendSiblingClones(
   let hasContent = false;
   let sibling = startElement;
 
+  // H2는 프레젠테이션 섹션의 경계이므로 합성 슬라이드도 다음 H2 앞에서 멈춘다.
   while (
     sibling &&
     sibling.tagName !== "H2" &&
@@ -521,6 +526,7 @@ function appendSiblingClones(
 }
 
 function openFirstDetails(slide: HTMLElement): void {
+  // 핵심 요약 슬라이드의 첫 details가 TL;DR이라는 현재 번역 글 구조를 전제로 한다.
   const details = slide.querySelector<HTMLDetailsElement>("details");
   if (details) details.open = true;
 }
@@ -563,6 +569,7 @@ function findSummaryIntroSplit(
 function findFirstIntroElement(startElement: Element | null): Element | null {
   let sibling = startElement;
   while (sibling && sibling.tagName !== "H2") {
+    // 연속된 hr은 도입 본문이 아니라 구분선으로 보고, H2는 다음 섹션의 경계로 본다.
     if (
       sibling.tagName !== "HR" &&
       !isAgendaBlock(sibling) &&

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -503,6 +503,10 @@ function buildSyntheticSectionSlide(startElement: Element): HTMLElement | null {
   return slide;
 }
 
+/**
+ * startElement부터 섹션 경계까지 형제 노드를 복제해 slide에 추가한다.
+ * 반환값은 실제로 의미 있는 콘텐츠가 하나라도 포함됐는지 여부다.
+ */
 function appendSiblingClones(
   slide: HTMLElement,
   startElement: Element | null,
@@ -535,9 +539,9 @@ function openSummaryDetails(slide: HTMLElement): void {
   const detailsElements = Array.from(
     slide.querySelectorAll<HTMLDetailsElement>(":scope > details")
   );
-  const details = detailsElements.find(details =>
+  const details = detailsElements.find(detailsElement =>
     TLDR_SUMMARY_PATTERN.test(
-      details.querySelector(":scope > summary")?.textContent ?? ""
+      detailsElement.querySelector(":scope > summary")?.textContent ?? ""
     )
   );
   if (details) details.open = true;
@@ -548,7 +552,7 @@ function findSummaryIntroSplit(
 ): { separator: Element; firstIntroElement: Element | null } | null {
   if (!SUMMARY_H2_PATTERN.test(getHeadingText(h2))) return null;
 
-  // details 요소 자체가 아니라, 이후 등장하는 hr을 분리 경계로 인정하기 위한 상태만 추적한다.
+  // 핵심 요약 details 이후 첫 hr만 요약/도입 경계로 인정한다.
   let sawDetails = false;
   let sibling = h2.nextElementSibling;
   while (sibling && sibling.tagName !== "H2") {

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -23,7 +23,7 @@ const AGENDA_SUMMARY_TEXT = "목차 보기";
  * astro.config.ts의 remark-collapse `test` 정규식과 의미 일치.
  */
 const AGENDA_H2_PATTERN = /^(table of contents|목차)$/i;
-const SUMMARY_H2_PATTERN = /^핵심 요약$/i;
+const SUMMARY_H2_PATTERN = /^핵심 요약$/;
 const MIN_SLIDES = 2;
 
 interface PresentationState {
@@ -540,6 +540,7 @@ function findSummaryIntroSplit(
       sawDetails = true;
     }
 
+    // details 없이 등장하는 hr은 일반 구분선일 수 있으므로 분리 기준으로 쓰지 않는다.
     if (sawDetails && sibling.tagName === "HR") {
       const firstIntroElement = findFirstIntroElement(
         sibling.nextElementSibling

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -450,7 +450,7 @@ function buildSectionSlides(h2: HTMLHeadingElement): HTMLElement[] {
   const summarySlide = buildSingleSectionSlide(h2, {
     stopBefore: summaryIntroSplit.separator,
   });
-  openSummaryDetails(summarySlide);
+  openTldrDetailsIfPresent(summarySlide);
 
   if (!summaryIntroSplit.firstIntroElement) {
     return [summarySlide];
@@ -489,8 +489,8 @@ function buildSingleSectionSlide(
 }
 
 /**
- * 제목 없는 도입 본문 슬라이드. 실질 콘텐츠가 없으면 호출부에서 도입 슬라이드를
- * 생략할 수 있도록 null을 반환한다.
+ * startElement부터 다음 H2 직전까지를 제목 없는 도입 본문 슬라이드로 만든다.
+ * 실질 콘텐츠가 없으면 호출부에서 도입 슬라이드를 생략할 수 있도록 null을 반환한다.
  */
 function buildSyntheticSectionSlide(startElement: Element): HTMLElement | null {
   const slide = document.createElement("section");
@@ -539,7 +539,7 @@ function appendSiblingClones(
  * 핵심 요약 슬라이드의 직계 details 중 TL;DR summary와 일치하는 항목만 펼친다.
  * 중첩 details는 현재 번역 글 구조의 핵심 요약 대상이 아니므로 건드리지 않는다.
  */
-function openSummaryDetails(slide: HTMLElement): void {
+function openTldrDetailsIfPresent(slide: HTMLElement): void {
   const detailsElements = Array.from(
     slide.querySelectorAll<HTMLDetailsElement>(":scope > details")
   );
@@ -556,7 +556,8 @@ function findSummaryIntroSplit(
 ): { separator: Element; firstIntroElement: Element | null } | null {
   if (!SUMMARY_H2_PATTERN.test(getHeadingText(h2))) return null;
 
-  // 핵심 요약 details 이후 첫 hr만 요약/도입 경계로 인정한다.
+  // details가 하나 이상 등장한 뒤 처음 만나는 hr만 요약/도입 경계로 인정한다.
+  // 여러 details가 있더라도 핵심 요약 블록 전체 뒤의 첫 구분선을 기준으로 분리한다.
   let sawDetails = false;
   let sibling = h2.nextElementSibling;
   while (sibling && sibling.tagName !== "H2") {
@@ -570,7 +571,6 @@ function findSummaryIntroSplit(
     }
 
     // details 없이 등장하는 hr은 일반 구분선일 수 있으므로 분리 기준으로 쓰지 않는다.
-    // details 이후 첫 hr만 요약/도입 경계로 인정한다.
     if (sawDetails && sibling.tagName === "HR") {
       const firstIntroElement = findFirstIntroElement(
         sibling.nextElementSibling

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -443,15 +443,19 @@ function buildSectionSlides(h2: HTMLHeadingElement): HTMLElement[] {
     return [buildSectionSlide(h2)];
   }
 
-  const summarySlide = buildSectionSlide(h2, {
-    stopBefore: summaryIntroSplit.separator,
-  });
-  openDetails(summarySlide);
   const introSlide = buildSyntheticSectionSlide(
     summaryIntroSplit.firstIntroElement
   );
+  if (!introSlide) {
+    return [buildSectionSlide(h2)];
+  }
 
-  return introSlide ? [summarySlide, introSlide] : [buildSectionSlide(h2)];
+  const summarySlide = buildSectionSlide(h2, {
+    stopBefore: summaryIntroSplit.separator,
+  });
+  openFirstDetails(summarySlide);
+
+  return [summarySlide, introSlide];
 }
 
 /**
@@ -468,22 +472,9 @@ function buildSectionSlide(
   const h2Clone = h2.cloneNode(true) as HTMLHeadingElement;
   slide.appendChild(h2Clone);
 
-  // 형제 노드 순회: 다음 h2를 만나기 전까지 복제
-  let sibling = h2.nextElementSibling;
-  while (
-    sibling &&
-    sibling.tagName !== "H2" &&
-    sibling !== options.stopBefore
-  ) {
-    // 목차 블록은 이미 별도 슬라이드로 처리되므로 제외
-    if (isAgendaBlock(sibling)) {
-      sibling = sibling.nextElementSibling;
-      continue;
-    }
-    const clone = sibling.cloneNode(true) as Element;
-    slide.appendChild(clone);
-    sibling = sibling.nextElementSibling;
-  }
+  appendSiblingClones(slide, h2.nextElementSibling, {
+    stopBefore: options.stopBefore,
+  });
 
   sanitizeSlide(slide);
   return slide;
@@ -493,9 +484,26 @@ function buildSyntheticSectionSlide(startElement: Element): HTMLElement | null {
   const slide = document.createElement("section");
   slide.className = "presentation-slide presentation-slide-section";
 
+  const hasContent = appendSiblingClones(slide, startElement);
+  if (!hasContent) return null;
+
+  sanitizeSlide(slide);
+  return slide;
+}
+
+function appendSiblingClones(
+  slide: HTMLElement,
+  startElement: Element | null,
+  options: { stopBefore?: Element } = {}
+): boolean {
   let hasContent = false;
-  let sibling: Element | null = startElement;
-  while (sibling && sibling.tagName !== "H2") {
+  let sibling = startElement;
+
+  while (
+    sibling &&
+    sibling.tagName !== "H2" &&
+    sibling !== options.stopBefore
+  ) {
     if (isAgendaBlock(sibling)) {
       sibling = sibling.nextElementSibling;
       continue;
@@ -507,16 +515,12 @@ function buildSyntheticSectionSlide(startElement: Element): HTMLElement | null {
     sibling = sibling.nextElementSibling;
   }
 
-  if (!hasContent) return null;
-
-  sanitizeSlide(slide);
-  return slide;
+  return hasContent;
 }
 
-function openDetails(slide: HTMLElement): void {
-  slide.querySelectorAll<HTMLDetailsElement>("details").forEach(details => {
-    details.open = true;
-  });
+function openFirstDetails(slide: HTMLElement): void {
+  const details = slide.querySelector<HTMLDetailsElement>("details");
+  if (details) details.open = true;
 }
 
 function findSummaryIntroSplit(

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -31,10 +31,16 @@ const MIN_SLIDES = 2;
 interface PresentationState {
   overlay: HTMLElement;
   slides: HTMLElement[];
+  slideSourceH2s: Array<HTMLHeadingElement | null>;
   currentIndex: number;
   triggerButton: HTMLButtonElement;
   inertedElements: Element[];
   controller: AbortController;
+}
+
+interface BuiltSlides {
+  slides: HTMLElement[];
+  slideSourceH2s: Array<HTMLHeadingElement | null>;
 }
 
 let state: PresentationState | null = null;
@@ -114,7 +120,7 @@ export function initializePresentationMode(): () => void {
 
 /**
  * 실제 조립 가능한 슬라이드 개수를 미리 계산.
- * 타이틀(1) + 목차(0 or 1) + H2 개수.
+ * 타이틀(1) + 목차(0 or 1) + H2 섹션들. 핵심 요약은 도입 본문 분리 여부까지 반영한다.
  */
 function countPotentialSlides(): number {
   const article = document.getElementById("article");
@@ -122,9 +128,16 @@ function countPotentialSlides(): number {
 
   const hasH1 = !!document.querySelector("main h1");
   const hasAgenda = !!findAgendaDetails(article);
-  const h2Count = article.querySelectorAll(":scope > h2").length;
+  const sectionSlideCount = Array.from(
+    article.querySelectorAll<HTMLHeadingElement>(":scope > h2")
+  )
+    .filter(h2 => !AGENDA_H2_PATTERN.test(getHeadingText(h2)))
+    .reduce((count, h2) => {
+      const split = findSummaryIntroSplit(h2);
+      return count + (split?.firstIntroElement ? 2 : 1);
+    }, 0);
 
-  return (hasH1 ? 1 : 0) + (hasAgenda ? 1 : 0) + h2Count;
+  return (hasH1 ? 1 : 0) + (hasAgenda ? 1 : 0) + sectionSlideCount;
 }
 
 /**
@@ -133,7 +146,7 @@ function countPotentialSlides(): number {
 function openOverlay(triggerButton: HTMLButtonElement): void {
   if (state) return; // 이미 열림
 
-  const slides = buildSlides();
+  const { slides, slideSourceH2s } = buildSlides();
   if (slides.length < MIN_SLIDES) return;
 
   const overlay = document.createElement("div");
@@ -198,6 +211,7 @@ function openOverlay(triggerButton: HTMLButtonElement): void {
   state = {
     overlay,
     slides,
+    slideSourceH2s,
     currentIndex: 0,
     triggerButton,
     inertedElements,
@@ -219,30 +233,19 @@ function closeOverlay(): void {
     inertedElements,
     controller,
     currentIndex,
-    slides,
+    slideSourceH2s,
   } = state;
 
   controller.abort();
 
-  // 원래 페이지에서 해당 H2로 스크롤 복귀
-  // (타이틀=0, 목차=1?, 첫 H2 = 1 or 2)
-  const article = document.getElementById("article");
-  if (article) {
-    const h2s = article.querySelectorAll<HTMLHeadingElement>(":scope > h2");
-    // slides 순서: title + (agenda?) + h2들. currentIndex가 H2 섹션인 경우 스크롤.
-    const sectionStartIndex = slides.findIndex(s =>
-      s.classList.contains("presentation-slide-section")
-    );
-    if (sectionStartIndex !== -1 && currentIndex >= sectionStartIndex) {
-      const h2Index = currentIndex - sectionStartIndex;
-      const targetH2 = h2s[h2Index];
-      if (targetH2) {
-        // 스크롤은 overlay 제거 후 다음 tick에 실행 (layout 안정화)
-        requestAnimationFrame(() => {
-          targetH2.scrollIntoView({ block: "start", behavior: "instant" });
-        });
-      }
-    }
+  // 원래 페이지에서 현재 슬라이드가 유래한 H2로 스크롤 복귀.
+  // 합성 도입 슬라이드처럼 H2 하나가 여러 슬라이드를 만들 수 있어 인덱스 산술을 쓰지 않는다.
+  const targetH2 = slideSourceH2s[currentIndex];
+  if (targetH2) {
+    // 스크롤은 overlay 제거 후 다음 tick에 실행 (layout 안정화)
+    requestAnimationFrame(() => {
+      targetH2.scrollIntoView({ block: "start", behavior: "instant" });
+    });
   }
 
   overlay.remove();
@@ -330,18 +333,23 @@ function updateCounter(): void {
 /**
  * 슬라이드 배열 조립.
  */
-function buildSlides(): HTMLElement[] {
+function buildSlides(): BuiltSlides {
   const slides: HTMLElement[] = [];
+  const slideSourceH2s: Array<HTMLHeadingElement | null> = [];
 
   const titleSlide = buildTitleSlide();
-  if (titleSlide) slides.push(titleSlide);
+  if (titleSlide) {
+    slides.push(titleSlide);
+    slideSourceH2s.push(null);
+  }
 
   const article = document.getElementById("article");
-  if (!article) return slides;
+  if (!article) return { slides, slideSourceH2s };
 
   const agendaDetails = findAgendaDetails(article);
   if (agendaDetails) {
     slides.push(buildAgendaSlide(agendaDetails));
+    slideSourceH2s.push(null);
   }
 
   // remark-collapse는 `<h2>목차</h2>`를 DOM에 그대로 둠. Agenda 슬라이드로 이미
@@ -352,10 +360,12 @@ function buildSlides(): HTMLElement[] {
     article.querySelectorAll<HTMLHeadingElement>(":scope > h2")
   ).filter(h2 => !AGENDA_H2_PATTERN.test(getHeadingText(h2)));
   for (const h2 of h2s) {
-    slides.push(...buildSectionSlides(h2));
+    const sectionSlides = buildSectionSlides(h2);
+    slides.push(...sectionSlides);
+    slideSourceH2s.push(...sectionSlides.map(() => h2));
   }
 
-  return slides;
+  return { slides, slideSourceH2s };
 }
 
 /**

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -23,6 +23,7 @@ const AGENDA_SUMMARY_TEXT = "목차 보기";
  * astro.config.ts의 remark-collapse `test` 정규식과 의미 일치.
  */
 const AGENDA_H2_PATTERN = /^(table of contents|목차)$/i;
+// 정확히 "핵심 요약"인 H2만 분리 대상으로 삼는다. 이모지나 부제목이 붙으면 일반 섹션으로 둔다.
 const SUMMARY_H2_PATTERN = /^핵심 요약$/;
 const MIN_SLIDES = 2;
 
@@ -450,6 +451,7 @@ function buildSectionSlides(h2: HTMLHeadingElement): HTMLElement[] {
     return [buildSectionSlide(h2)];
   }
 
+  // separator(hr)는 요약과 도입을 나누는 경계일 뿐, 요약 슬라이드에는 포함하지 않는다.
   const summarySlide = buildSectionSlide(h2, {
     stopBefore: summaryIntroSplit.separator,
   });
@@ -511,7 +513,7 @@ function appendSiblingClones(
 
     const clone = sibling.cloneNode(true) as Element;
     slide.appendChild(clone);
-    hasContent = true;
+    hasContent ||= hasMeaningfulSlideContent(sibling);
     sibling = sibling.nextElementSibling;
   }
 
@@ -560,12 +562,25 @@ function findSummaryIntroSplit(
 function findFirstIntroElement(startElement: Element | null): Element | null {
   let sibling = startElement;
   while (sibling && sibling.tagName !== "H2") {
-    if (sibling.tagName !== "HR" && !isAgendaBlock(sibling)) {
+    if (
+      sibling.tagName !== "HR" &&
+      !isAgendaBlock(sibling) &&
+      hasMeaningfulSlideContent(sibling)
+    ) {
       return sibling;
     }
     sibling = sibling.nextElementSibling;
   }
   return null;
+}
+
+function hasMeaningfulSlideContent(element: Element): boolean {
+  if (element.textContent?.trim()) return true;
+  return element.querySelector(
+    "img, picture, video, audio, canvas, svg, iframe, table, pre"
+  )
+    ? true
+    : false;
 }
 
 /**

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -530,6 +530,7 @@ function findSummaryIntroSplit(
 ): { separator: Element; firstIntroElement: Element } | null {
   if (!SUMMARY_H2_PATTERN.test(getHeadingText(h2))) return null;
 
+  // details 요소 자체가 아니라, 이후 등장하는 hr을 분리 경계로 인정하기 위한 상태만 추적한다.
   let sawDetails = false;
   let sibling = h2.nextElementSibling;
   while (sibling && sibling.tagName !== "H2") {
@@ -576,11 +577,9 @@ function findFirstIntroElement(startElement: Element | null): Element | null {
 
 function hasMeaningfulSlideContent(element: Element): boolean {
   if (element.textContent?.trim()) return true;
-  return element.querySelector(
+  return !!element.querySelector(
     "img, picture, video, audio, canvas, svg, iframe, table, pre"
-  )
-    ? true
-    : false;
+  );
 }
 
 /**

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -535,12 +535,11 @@ function openSummaryDetails(slide: HTMLElement): void {
   const detailsElements = Array.from(
     slide.querySelectorAll<HTMLDetailsElement>(":scope > details")
   );
-  const details =
-    detailsElements.find(details =>
-      TLDR_SUMMARY_PATTERN.test(
-        details.querySelector(":scope > summary")?.textContent ?? ""
-      )
-    ) ?? detailsElements[0];
+  const details = detailsElements.find(details =>
+    TLDR_SUMMARY_PATTERN.test(
+      details.querySelector(":scope > summary")?.textContent ?? ""
+    )
+  );
   if (details) details.open = true;
 }
 
@@ -563,6 +562,7 @@ function findSummaryIntroSplit(
     }
 
     // details 없이 등장하는 hr은 일반 구분선일 수 있으므로 분리 기준으로 쓰지 않는다.
+    // details 이후 첫 hr만 요약/도입 경계로 인정한다.
     if (sawDetails && sibling.tagName === "HR") {
       const firstIntroElement = findFirstIntroElement(
         sibling.nextElementSibling


### PR DESCRIPTION
## 변경 사항

- 번역 글의 `핵심 요약 → details → hr → 도입 본문` 패턴을 프레젠테이션 모드에서 감지해 요약 슬라이드와 도입 본문 슬라이드를 분리했습니다.
- 원본 마크다운과 실제 글 DOM에는 없는 헤더를 추가하지 않고, 도입 본문은 제목 없는 프레젠테이션 전용 슬라이드로 렌더링합니다.
- 프레젠테이션 모드의 핵심 요약 슬라이드에서는 TL;DR `details`가 기본으로 열린 상태가 되도록 했습니다.
- 해당 동작을 보장하는 Playwright 회귀 테스트를 추가했습니다.

## 배경

번역 글에서는 원문에 없는 H2를 임의로 추가하기 어렵습니다. 기존 프레젠테이션 모드는 H2부터 다음 H2 직전까지를 한 슬라이드로 묶기 때문에, 핵심 요약 아래 도입 본문이 같은 슬라이드에 섞이는 문제가 있었습니다.

## 검증

- `pnpm test e2e/presentation-mode.spec.ts`
- `pnpm lint`
- `pnpm build`