### PR TITLE
fix(seo): noindex 페이지에 JSON-LD 구조화 데이터 미렌더

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -40,7 +40,8 @@ const keywords = tags.length > 0 ? tags : SITE.keywords;
 const socialImageURL = new URL(ogImage, Astro.url);
 
 // noindex 페이지는 검색엔진이 색인하지 않으므로 구조화 데이터를 싣지 않는다
-const noindex = robots?.includes("noindex") ?? false;
+// robots 디렉티브는 대소문자를 구분하지 않으며 none = noindex + nofollow와 동등
+const noindex = /noindex|none/i.test(robots ?? "");
 
 // 페이지 타입에 따른 JSON-LD 구조화 데이터
 const structuredData = noindex

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -39,9 +39,13 @@ const keywords = tags.length > 0 ? tags : SITE.keywords;
 
 const socialImageURL = new URL(ogImage, Astro.url);
 
+// noindex 페이지는 검색엔진이 색인하지 않으므로 구조화 데이터를 싣지 않는다
+const noindex = robots?.includes("noindex") ?? false;
+
 // 페이지 타입에 따른 JSON-LD 구조화 데이터
-const structuredData =
-  pageType === "article"
+const structuredData = noindex
+  ? null
+  : pageType === "article"
     ? {
         "@context": "https://schema.org",
         "@type": "BlogPosting",
@@ -68,6 +72,7 @@ const structuredData =
           name: SITE.author,
           alternateName: SITE.authorEn,
           description: SITE.authorDescription,
+          // 인물의 정규 프로필 페이지(고정값). 현재 페이지 canonical이 아님.
           url: `${SITE.website}/about`,
           image: `${socialImageURL}`,
           sameAs: [SITE.social.github, SITE.social.linkedin],
@@ -187,11 +192,15 @@ const structuredData =
     <meta property="twitter:image" content={socialImageURL} />
 
     <!-- Google JSON-LD Structured data -->
-    <script
-      type="application/ld+json"
-      is:inline
-      set:html={JSON.stringify(structuredData)}
-    />
+    {
+      structuredData && (
+        <script
+          type="application/ld+json"
+          is:inline
+          set:html={JSON.stringify(structuredData)}
+        />
+      )
+    }
 
     <!-- Enable RSS feed auto-discovery  -->
     <!-- https://docs.astro.build/en/recipes/rss/#enabling-rss-feed-auto-discovery -->


### PR DESCRIPTION
## Description

`pageType="profile"`을 전달하는 레이아웃은 `AboutLayout`(`/about`)과 `PortfolioLayout`(`/portfolio`) 두 개입니다. `Layout.astro`의 Person JSON-LD는 `url`이 `${SITE.website}/about`로 고정돼 있어, `noindex` 페이지인 `/portfolio`에도 Person 구조화 데이터가 렌더되고 `url`이 잘못 `/about`을 가리켰습니다.

`robots` prop에 `noindex`가 포함되면 JSON-LD 자체를 렌더하지 않도록 게이팅했습니다. 검색엔진은 색인하지 않을 페이지의 구조화 데이터를 사용하지 않으므로, `/portfolio` 전용 분기가 아닌 일반 규칙으로 처리해 향후 추가될 `noindex` 페이지에도 자동 적용됩니다.

**변경 파일**: `src/layouts/Layout.astro` (단일 파일, +16 / −7)

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

검토한 세 가지 방안:

- **`url`을 prop으로 전달**: `/portfolio`가 여전히 Person 스키마를 렌더하므로 `url`이 `noindex` 페이지를 가리키는 의미적 모순이 남습니다.
- **canonical 기반 동적 설정**: `/portfolio`에서 `url`이 `/portfolio`가 되어 동일한 문제. schema.org `Person.url`은 "그 인물의 정규 프로필 페이지"를 의미하므로 현재 페이지 canonical과 개념이 다릅니다.
- **채택 — `noindex` 페이지에서 구조화 데이터 미렌더**: `/portfolio`는 `robots: "noindex, nofollow"`라 구조화 데이터의 SEO 가치가 0입니다.

구현 노트:

- `structuredData`가 `null`일 때 `<script>` 엘리먼트 자체를 조건부 렌더 — `JSON.stringify(null)`이 `"null"` 문자열을 출력하는 것을 방지.
- `Person.url`은 `${SITE.website}/about` 고정값을 유지(사이트 차원의 정규 프로필 URL). 다음 수정자가 `canonicalURL`로 바꿔 버그를 재도입하지 않도록 의도 주석을 추가.

### 검증

- `pnpm build` 통과(164 페이지 빌드, `astro check` 타입체크 통과), `pnpm lint`·`pnpm format` 통과
- `dist/about/index.html`: JSON-LD Person 존재, `"url":"https://caesiumy.dev/about"` — 변경 전과 동일
- `dist/portfolio/index.html`: `application/ld+json` 0건(제거됨), `og:type="profile"`·`robots="noindex, nofollow"` 메타는 영향 없이 유지

## Related Issue

해당 없음