### PR TITLE
fix(scripts): View Transitions 리스너 누수 4건 일괄 수정

### DIFF
--- a/e2e/continue-reading.spec.ts
+++ b/e2e/continue-reading.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { TEST_POST_SLUG, TEST_POST_URL } from "./fixtures/test-posts";
 
 declare global {
   interface Window {
@@ -11,10 +12,6 @@ declare global {
 }
 
 const STORAGE_KEY = "blog-scroll-positions";
-
-// 테스트용 블로그 포스트 (slug frontmatter 없음 - URL과 localStorage 키 일치)
-const TEST_POST_SLUG = "ai/claude-code-token-burning-session-retrospect";
-const TEST_POST_URL = `/posts/${TEST_POST_SLUG}`;
 
 /**
  * localStorage에 스크롤 위치 저장

--- a/e2e/fixtures/test-posts.ts
+++ b/e2e/fixtures/test-posts.ts
@@ -1,0 +1,10 @@
+/**
+ * E2E 스펙 공용 테스트 포스트.
+ *
+ * 선정 조건 (slug 교체 시에도 모두 만족해야 함):
+ * - slug frontmatter 없음 → URL 경로와 localStorage 키가 일치 (continue-reading 요구)
+ * - PostNavigation의 이전/다음 글 링크 존재 (listener-leak의 View Transitions 왕복 요구)
+ * - 스크롤 가능 높이가 충분히 긴 글 (back-to-top 30% 가시성 임계 검증 요구)
+ */
+export const TEST_POST_SLUG = "ai/claude-code-token-burning-session-retrospect";
+export const TEST_POST_URL = `/posts/${TEST_POST_SLUG}`;

--- a/e2e/listener-leak.spec.ts
+++ b/e2e/listener-leak.spec.ts
@@ -1,0 +1,280 @@
+import { test, expect, type Page } from "@playwright/test";
+
+declare global {
+  interface Window {
+    /** 테스트 스텁: (타겟:타입)별 현재 등록된 리스너 수 스냅샷 */
+    __listenerCounts?: () => Record<string, number>;
+  }
+}
+
+const STORAGE_KEY = "blog-scroll-positions";
+
+// 테스트용 블로그 포스트 (continue-reading.spec.ts와 동일 — 이전/다음 글이 있는 긴 글)
+const TEST_POST_SLUG = "ai/claude-code-token-burning-session-retrospect";
+const TEST_POST_URL = `/posts/${TEST_POST_SLUG}`;
+
+/**
+ * EventTarget.prototype을 래핑해 영속 타겟(document, MediaQueryList)의
+ * 리스너를 Set으로 추적하는 스텁 주입.
+ *
+ * - getEventListeners는 CDP 전용이라 사용 불가 → window에 카운터 노출 방식
+ * - AbortSignal 기반 해제(abort)와 removeEventListener 모두 추적
+ * - Set.delete는 멱등이라 abort+remove 중복 해제에도 안전
+ * - View Transitions 스왑에서는 window가 유지되므로 스텁과 카운터가 살아남음
+ */
+async function installListenerTracker(page: Page) {
+  await page.addInitScript(() => {
+    const counts = new Map<string, Set<unknown>>();
+
+    const keyFor = (target: EventTarget, type: string): string | null => {
+      if (
+        target === document &&
+        (type === "scroll" || type === "click" || type === "keydown")
+      ) {
+        return `document:${type}`;
+      }
+      if (
+        typeof MediaQueryList !== "undefined" &&
+        target instanceof MediaQueryList &&
+        type === "change"
+      ) {
+        return "mql:change";
+      }
+      return null;
+    };
+
+    window.__listenerCounts = () => {
+      const snapshot: Record<string, number> = {};
+      for (const [key, set] of counts) snapshot[key] = set.size;
+      return snapshot;
+    };
+
+    const origAdd = EventTarget.prototype.addEventListener;
+    const origRemove = EventTarget.prototype.removeEventListener;
+
+    EventTarget.prototype.addEventListener = function (
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | AddEventListenerOptions
+    ) {
+      const key = listener ? keyFor(this, type) : null;
+      if (key && listener) {
+        let set = counts.get(key);
+        if (!set) {
+          set = new Set();
+          counts.set(key, set);
+        }
+        const trackedSet = set;
+        trackedSet.add(listener);
+
+        const signal =
+          options && typeof options === "object" ? options.signal : undefined;
+        if (signal?.aborted) {
+          trackedSet.delete(listener);
+        } else {
+          // AbortSignal도 EventTarget이지만 keyFor가 null을 반환해 무한 재귀 없음
+          signal?.addEventListener("abort", () => trackedSet.delete(listener), {
+            once: true,
+          });
+        }
+      }
+      return origAdd.call(this, type, listener, options);
+    };
+
+    EventTarget.prototype.removeEventListener = function (
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | EventListenerOptions
+    ) {
+      const key = listener ? keyFor(this, type) : null;
+      if (key && listener) counts.get(key)?.delete(listener);
+      return origRemove.call(this, type, listener, options);
+    };
+  });
+}
+
+/**
+ * View Transitions 스왑 후 astro:page-load 초기화까지 대기.
+ * VT 스왑은 Playwright load state와 무관하므로 고정 대기를 사용.
+ */
+async function waitForPageSettled(page: Page) {
+  await page.waitForSelector("main", { state: "visible" });
+  await page.waitForTimeout(800);
+}
+
+/** 스크롤 가능 높이의 50% 지점으로 즉시 스크롤 (back-to-top 가시성 임계 30% 초과) */
+async function scrollToHalf(page: Page) {
+  await page.evaluate(() => {
+    const max = document.documentElement.scrollHeight - window.innerHeight;
+    window.scrollTo({ top: max * 0.5, behavior: "instant" });
+  });
+}
+
+/** "이어 읽기" 토스트/스크롤 복원 간섭 차단용 저장소 정리 */
+async function clearScrollStorage(page: Page) {
+  await page.evaluate(key => localStorage.removeItem(key), STORAGE_KEY);
+}
+
+/**
+ * PostNavigation 링크 클릭으로 이웃 글로 View Transitions 스왑.
+ * page.goto는 풀 페이지 로드라 VT 경로를 타지 않으므로 링크 클릭 필수.
+ */
+async function gotoNeighborPost(
+  page: Page
+): Promise<{ postPath: string; neighborPath: string }> {
+  const postPath = new URL(page.url()).pathname;
+  const navLink = page.locator("a", { hasText: /이전 글|다음 글/ }).first();
+  await expect(navLink).toBeVisible();
+  await navLink.click();
+  await page.waitForURL(url => url.pathname !== postPath);
+  await waitForPageSettled(page);
+  return { postPath, neighborPath: new URL(page.url()).pathname };
+}
+
+test.beforeEach(async ({ page }) => {
+  await installListenerTracker(page);
+  // 풀 로드마다 "이어 읽기" 저장소 초기화 (토스트/스크롤 복원 간섭 차단)
+  await page.addInitScript(key => {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      /* localStorage 접근 불가 환경은 무시 */
+    }
+  }, STORAGE_KEY);
+});
+
+test.describe("View Transitions 리스너 수명", () => {
+  test("글↔글 왕복 후 영속 타겟 리스너 수가 늘지 않는다", async ({ page }) => {
+    await page.goto(TEST_POST_URL);
+    await waitForPageSettled(page);
+    const baseline = await page.evaluate(() => window.__listenerCounts!());
+
+    const { postPath, neighborPath } = await gotoNeighborPost(page);
+
+    // 글↔글 왕복 — popstate도 ClientRouter가 가로채 View Transitions 스왑이 됨
+    for (let round = 0; round < 3; round++) {
+      await page.goBack();
+      await page.waitForURL(url => url.pathname === postPath);
+      await waitForPageSettled(page);
+
+      if (round < 2) {
+        await page.goForward();
+        await page.waitForURL(url => url.pathname === neighborPath);
+        await waitForPageSettled(page);
+      }
+    }
+
+    // 첫 진입 시점과 동일해야 함 (절대값이 아닌 불변량 비교 —
+    // 다른 컴포넌트가 등록하는 리스너 수와 무관하게 누적만 검출)
+    const final = await page.evaluate(() => window.__listenerCounts!());
+    expect(final).toEqual(baseline);
+  });
+
+  test("back-to-top: 30% 초과 스크롤 시 표시, 클릭 시 최상단 복귀", async ({
+    page,
+  }) => {
+    await page.goto(TEST_POST_URL);
+    await waitForPageSettled(page);
+
+    const container = page.locator("#btt-btn-container");
+    await expect(container).toHaveClass(/opacity-0/);
+
+    await scrollToHalf(page);
+    await expect(container).toHaveClass(/opacity-100/);
+
+    // 진행률 인디케이터 — 데스크톱 뷰포트에선 md:hidden이라 inline style로 검증
+    const backgroundImage = await page
+      .locator("#progress-indicator")
+      .evaluate(el => el.style.backgroundImage);
+    expect(backgroundImage).toContain("conic-gradient");
+
+    await page.locator("[data-button='back-to-top']").click();
+    // html scroll-smooth 가능성 대응 — 최상단 도달까지 대기
+    await page.waitForFunction(() => window.scrollY < 10);
+    await expect(container).toHaveClass(/opacity-0/);
+  });
+
+  test("왕복 네비게이션 후에도 back-to-top·진행률 바가 정상 동작", async ({
+    page,
+  }) => {
+    await page.goto(TEST_POST_URL);
+    await waitForPageSettled(page);
+
+    const { postPath } = await gotoNeighborPost(page);
+
+    // 복귀 전 저장소 정리 — "이어 읽기" 토스트가 버튼을 가리지 않도록
+    await clearScrollStorage(page);
+    await page.goBack();
+    await page.waitForURL(url => url.pathname === postPath);
+    await waitForPageSettled(page);
+
+    // 진행률 바 재초기화 확인 (멱등 가드의 리셋 누락 회귀 방지)
+    await expect(page.locator("#myBar")).toHaveCount(1);
+
+    // back-to-top이 새 DOM에 재바인딩됐는지 (과잉 정리 회귀 방지)
+    const container = page.locator("#btt-btn-container");
+    await scrollToHalf(page);
+    await expect(container).toHaveClass(/opacity-100/);
+
+    await page.locator("[data-button='back-to-top']").click();
+    await page.waitForFunction(() => window.scrollY < 10);
+    await expect(container).toHaveClass(/opacity-0/);
+  });
+
+  test("공유 URL 복사 버튼이 View Transitions 스왑 후에도 동작", async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    await page.goto(TEST_POST_URL);
+    await waitForPageSettled(page);
+
+    // 첫 글: 버튼 동작 확인 (성공/실패 어느 경로든 피드백 opacity=1)
+    const feedback = page.locator("#copy-feedback");
+    await page.locator("#copy-url-btn").click();
+    await expect(feedback).toHaveCSS("opacity", "1");
+
+    // 이웃 글로 스왑 — 모듈 스크립트는 세션당 1회만 실행되므로
+    // page-load 재초기화가 없으면 새 페이지의 버튼이 무반응이 됨
+    await gotoNeighborPost(page);
+
+    await page.locator("#copy-url-btn").click();
+    await expect(page.locator("#copy-feedback")).toHaveCSS("opacity", "1");
+  });
+});
+
+test.describe("모바일 메뉴 (Navigation 리스너 검증)", () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test("토글·외부 클릭·Escape 닫기가 왕복 후에도 정상", async ({ page }) => {
+    await page.goto(TEST_POST_URL);
+    await waitForPageSettled(page);
+
+    const menuBtn = page.locator("[data-menu-btn]");
+    const menuItems = page.locator("[data-menu-items]");
+
+    await menuBtn.click();
+    await expect(menuItems).toHaveAttribute("data-state", "open");
+
+    // 외부 클릭 → 닫힘 (모바일 시트가 상단 콘텐츠를 덮으므로 body 직접 클릭)
+    await page.evaluate(() => document.body.click());
+    await expect(menuItems).toHaveAttribute("data-state", "closed");
+
+    await menuBtn.click();
+    await expect(menuItems).toHaveAttribute("data-state", "open");
+    await page.keyboard.press("Escape");
+    await expect(menuItems).toHaveAttribute("data-state", "closed");
+
+    // 왕복 후에도 동일 동작 (재바인딩 회귀 방지)
+    const { postPath } = await gotoNeighborPost(page);
+    await page.goBack();
+    await page.waitForURL(url => url.pathname === postPath);
+    await waitForPageSettled(page);
+
+    await menuBtn.click();
+    await expect(menuItems).toHaveAttribute("data-state", "open");
+    await page.keyboard.press("Escape");
+    await expect(menuItems).toHaveAttribute("data-state", "closed");
+  });
+});

--- a/e2e/listener-leak.spec.ts
+++ b/e2e/listener-leak.spec.ts
@@ -1,29 +1,38 @@
 import { test, expect, type Page } from "@playwright/test";
+import { TEST_POST_URL } from "./fixtures/test-posts";
 
 declare global {
   interface Window {
     /** 테스트 스텁: (타겟:타입)별 현재 등록된 리스너 수 스냅샷 */
     __listenerCounts?: () => Record<string, number>;
+    /** 테스트 스텁: astro:page-load 발생 횟수 (풀 로드마다 0으로 리셋) */
+    __pageLoadCount?: number;
+    /** waitForListenerCountsStable의 직전 폴링 샘플 */
+    __lastCountsSample?: string;
   }
 }
 
 const STORAGE_KEY = "blog-scroll-positions";
 
-// 테스트용 블로그 포스트 (continue-reading.spec.ts와 동일 — 이전/다음 글이 있는 긴 글)
-const TEST_POST_SLUG = "ai/claude-code-token-burning-session-retrospect";
-const TEST_POST_URL = `/posts/${TEST_POST_SLUG}`;
-
 /**
  * EventTarget.prototype을 래핑해 영속 타겟(document, MediaQueryList)의
- * 리스너를 Set으로 추적하는 스텁 주입.
+ * 리스너를 Set으로 추적하는 스텁 + astro:page-load 카운터 주입.
  *
  * - getEventListeners는 CDP 전용이라 사용 불가 → window에 카운터 노출 방식
  * - AbortSignal 기반 해제(abort)와 removeEventListener 모두 추적
  * - Set.delete는 멱등이라 abort+remove 중복 해제에도 안전
  * - View Transitions 스왑에서는 window가 유지되므로 스텁과 카운터가 살아남음
+ * - page-load 카운터는 고정 시간 대기 없이 "스왑 완료 + 동기 초기화 완료"를
+ *   결정론적으로 감지하기 위한 신호 (디스패치가 동기라, 폴링이 증가를 관측한
+ *   시점엔 모든 astro:page-load 핸들러 실행이 끝나 있음)
  */
-async function installListenerTracker(page: Page) {
+async function installTestInstrumentation(page: Page) {
   await page.addInitScript(() => {
+    window.__pageLoadCount = 0;
+    document.addEventListener("astro:page-load", () => {
+      window.__pageLoadCount = (window.__pageLoadCount ?? 0) + 1;
+    });
+
     const counts = new Map<string, Set<unknown>>();
 
     const keyFor = (target: EventTarget, type: string): string | null => {
@@ -93,13 +102,45 @@ async function installListenerTracker(page: Page) {
   });
 }
 
-/**
- * View Transitions 스왑 후 astro:page-load 초기화까지 대기.
- * VT 스왑은 Playwright load state와 무관하므로 고정 대기를 사용.
- */
-async function waitForPageSettled(page: Page) {
+/** 초기 풀 로드 후 첫 astro:page-load 발생(동기 초기화 완료)까지 대기 */
+async function waitForInitialPageLoad(page: Page) {
   await page.waitForSelector("main", { state: "visible" });
-  await page.waitForTimeout(800);
+  await page.waitForFunction(() => (window.__pageLoadCount ?? 0) >= 1);
+}
+
+/**
+ * View Transitions 네비게이션을 트리거하고 다음 astro:page-load 완료까지 대기.
+ * 풀 로드가 끼어들면 카운터가 리셋돼 조건이 성립하지 않으므로,
+ * "VT 경로를 탔다"는 사실 자체도 함께 검증된다.
+ */
+async function withViewTransition(page: Page, action: () => Promise<void>) {
+  const before = await page.evaluate(() => window.__pageLoadCount ?? 0);
+  await action();
+  await page.waitForFunction(
+    prev => (window.__pageLoadCount ?? 0) > prev,
+    before
+  );
+}
+
+/**
+ * 추적 카운트가 연속 두 폴링 샘플(150ms 간격)에서 동일해질 때까지 대기.
+ * client:only 아일랜드(React)의 비동기 마운트가 등록하는 리스너까지
+ * 측정 전에 흡수해, 측정 시점 차이로 인한 플레이키를 방지한다.
+ */
+async function waitForListenerCountsStable(page: Page) {
+  await page.evaluate(() => {
+    delete window.__lastCountsSample;
+  });
+  await page.waitForFunction(
+    () => {
+      const current = JSON.stringify(window.__listenerCounts?.() ?? {});
+      const previous = window.__lastCountsSample;
+      window.__lastCountsSample = current;
+      return previous === current;
+    },
+    undefined,
+    { polling: 150 }
+  );
 }
 
 /** 스크롤 가능 높이의 50% 지점으로 즉시 스크롤 (back-to-top 가시성 임계 30% 초과) */
@@ -125,14 +166,31 @@ async function gotoNeighborPost(
   const postPath = new URL(page.url()).pathname;
   const navLink = page.locator("a", { hasText: /이전 글|다음 글/ }).first();
   await expect(navLink).toBeVisible();
-  await navLink.click();
-  await page.waitForURL(url => url.pathname !== postPath);
-  await waitForPageSettled(page);
+  await withViewTransition(page, async () => {
+    await navLink.click();
+    await page.waitForURL(url => url.pathname !== postPath);
+  });
   return { postPath, neighborPath: new URL(page.url()).pathname };
 }
 
+/** 히스토리 이동(뒤로/앞으로)을 VT 스왑으로 수행하고 도착 경로를 확인 */
+async function historyNavigate(
+  page: Page,
+  direction: "back" | "forward",
+  expectedPath: string
+) {
+  await withViewTransition(page, async () => {
+    if (direction === "back") {
+      await page.goBack();
+    } else {
+      await page.goForward();
+    }
+    await page.waitForURL(url => url.pathname === expectedPath);
+  });
+}
+
 test.beforeEach(async ({ page }) => {
-  await installListenerTracker(page);
+  await installTestInstrumentation(page);
   // 풀 로드마다 "이어 읽기" 저장소 초기화 (토스트/스크롤 복원 간섭 차단)
   await page.addInitScript(key => {
     try {
@@ -146,26 +204,25 @@ test.beforeEach(async ({ page }) => {
 test.describe("View Transitions 리스너 수명", () => {
   test("글↔글 왕복 후 영속 타겟 리스너 수가 늘지 않는다", async ({ page }) => {
     await page.goto(TEST_POST_URL);
-    await waitForPageSettled(page);
+    await waitForInitialPageLoad(page);
+
+    // 워밍업 왕복: 베이스라인을 "스왑으로 도착한 테스트 포스트" 상태로 만들어
+    // 본 측정과 동일 조건으로 맞추고, 첫 스왑에서만 발생하는 일회성 등록을 흡수
+    const { postPath, neighborPath } = await gotoNeighborPost(page);
+    await historyNavigate(page, "back", postPath);
+
+    await waitForListenerCountsStable(page);
     const baseline = await page.evaluate(() => window.__listenerCounts!());
 
-    const { postPath, neighborPath } = await gotoNeighborPost(page);
-
-    // 글↔글 왕복 — popstate도 ClientRouter가 가로채 View Transitions 스왑이 됨
+    // 글↔글 왕복 3회 — popstate도 ClientRouter가 가로채 View Transitions 스왑이 됨
     for (let round = 0; round < 3; round++) {
-      await page.goBack();
-      await page.waitForURL(url => url.pathname === postPath);
-      await waitForPageSettled(page);
-
-      if (round < 2) {
-        await page.goForward();
-        await page.waitForURL(url => url.pathname === neighborPath);
-        await waitForPageSettled(page);
-      }
+      await historyNavigate(page, "forward", neighborPath);
+      await historyNavigate(page, "back", postPath);
     }
 
-    // 첫 진입 시점과 동일해야 함 (절대값이 아닌 불변량 비교 —
+    // 베이스라인과 동일해야 함 (절대값이 아닌 불변량 비교 —
     // 다른 컴포넌트가 등록하는 리스너 수와 무관하게 누적만 검출)
+    await waitForListenerCountsStable(page);
     const final = await page.evaluate(() => window.__listenerCounts!());
     expect(final).toEqual(baseline);
   });
@@ -174,7 +231,7 @@ test.describe("View Transitions 리스너 수명", () => {
     page,
   }) => {
     await page.goto(TEST_POST_URL);
-    await waitForPageSettled(page);
+    await waitForInitialPageLoad(page);
 
     const container = page.locator("#btt-btn-container");
     await expect(container).toHaveClass(/opacity-0/);
@@ -198,15 +255,13 @@ test.describe("View Transitions 리스너 수명", () => {
     page,
   }) => {
     await page.goto(TEST_POST_URL);
-    await waitForPageSettled(page);
+    await waitForInitialPageLoad(page);
 
     const { postPath } = await gotoNeighborPost(page);
 
     // 복귀 전 저장소 정리 — "이어 읽기" 토스트가 버튼을 가리지 않도록
     await clearScrollStorage(page);
-    await page.goBack();
-    await page.waitForURL(url => url.pathname === postPath);
-    await waitForPageSettled(page);
+    await historyNavigate(page, "back", postPath);
 
     // 진행률 바 재초기화 확인 (멱등 가드의 리셋 누락 회귀 방지)
     await expect(page.locator("#myBar")).toHaveCount(1);
@@ -228,7 +283,7 @@ test.describe("View Transitions 리스너 수명", () => {
     await context.grantPermissions(["clipboard-read", "clipboard-write"]);
 
     await page.goto(TEST_POST_URL);
-    await waitForPageSettled(page);
+    await waitForInitialPageLoad(page);
 
     // 첫 글: 버튼 동작 확인 (성공/실패 어느 경로든 피드백 opacity=1)
     const feedback = page.locator("#copy-feedback");
@@ -249,7 +304,7 @@ test.describe("모바일 메뉴 (Navigation 리스너 검증)", () => {
 
   test("토글·외부 클릭·Escape 닫기가 왕복 후에도 정상", async ({ page }) => {
     await page.goto(TEST_POST_URL);
-    await waitForPageSettled(page);
+    await waitForInitialPageLoad(page);
 
     const menuBtn = page.locator("[data-menu-btn]");
     const menuItems = page.locator("[data-menu-items]");
@@ -268,9 +323,7 @@ test.describe("모바일 메뉴 (Navigation 리스너 검증)", () => {
 
     // 왕복 후에도 동일 동작 (재바인딩 회귀 방지)
     const { postPath } = await gotoNeighborPost(page);
-    await page.goBack();
-    await page.waitForURL(url => url.pathname === postPath);
-    await waitForPageSettled(page);
+    await historyNavigate(page, "back", postPath);
 
     await menuBtn.click();
     await expect(menuItems).toHaveAttribute("data-state", "open");

--- a/e2e/listener-leak.spec.ts
+++ b/e2e/listener-leak.spec.ts
@@ -133,7 +133,9 @@ async function waitForListenerCountsStable(page: Page) {
   });
   await page.waitForFunction(
     () => {
-      const current = JSON.stringify(window.__listenerCounts?.() ?? {});
+      // 스텁 누락 시 ?.()는 "{}"끼리 비교돼 조용히 통과하므로, 측정부와 동일하게
+      // non-null 단언을 써서 시끄럽게 실패하도록 통일
+      const current = JSON.stringify(window.__listenerCounts!());
       const previous = window.__lastCountsSample;
       window.__lastCountsSample = current;
       return previous === current;

--- a/src/features/blog/components/ShareLinks.astro
+++ b/src/features/blog/components/ShareLinks.astro
@@ -115,7 +115,10 @@ import { Icon } from "astro-icon/components";
     }
   }
 
-  // 초기 로드 + View Transitions 스왑 모두 커버
+  // 초기 로드 + View Transitions 스왑 모두 커버.
+  // astro:page-load는 초기 로드에도 발생해 직접 호출과 겹치지만(가드가 1회 바인딩 보장),
+  // ClientRouter 부재·로드 타이밍과 무관하게 동작을 보장하는 의도적 이중 경로다.
+  // PostDetails·BackButton과 동일 컨벤션이므로 직접 호출을 제거하지 말 것.
   initShareLinks();
   document.addEventListener("astro:page-load", initShareLinks);
 </script>

--- a/src/features/blog/components/ShareLinks.astro
+++ b/src/features/blog/components/ShareLinks.astro
@@ -37,12 +37,22 @@ import { Icon } from "astro-icon/components";
 </div>
 
 <script>
-  const copyButton = document.getElementById("copy-url-btn");
-  const feedback = document.getElementById("copy-feedback");
-  const copyIcon = document.getElementById("copy-icon");
-  const checkIcon = document.getElementById("check-icon");
+  // 모듈 스크립트는 세션당 1회만 실행된다. 모듈 스코프에서 요소를 잡아 바인딩하면
+  // View Transitions 스왑 이후의 새 버튼은 리스너가 없고(무반응), 모듈 스코프 참조가
+  // 첫 페이지의 detached 노드를 세션 내내 붙잡는다. 페이지마다 재초기화한다.
+  function initShareLinks() {
+    const copyButton = document.getElementById("copy-url-btn");
+    const feedback = document.getElementById("copy-feedback");
+    const copyIcon = document.getElementById("copy-icon");
+    const checkIcon = document.getElementById("check-icon");
 
-  if (copyButton && feedback && copyIcon && checkIcon) {
+    if (!copyButton || !feedback || !copyIcon || !checkIcon) return;
+
+    // 초기 로드 시 직접 호출 + astro:page-load 이중 실행 대비 (버튼은 스왑마다
+    // 새 DOM이라 가드가 자연 리셋됨)
+    if (copyButton.dataset.copyUrlInitialized) return;
+    copyButton.dataset.copyUrlInitialized = "true";
+
     copyButton.addEventListener("click", async () => {
       try {
         await navigator.clipboard.writeText(window.location.href);
@@ -104,4 +114,8 @@ import { Icon } from "astro-icon/components";
       }
     }
   }
+
+  // 초기 로드 + View Transitions 스왑 모두 커버
+  initShareLinks();
+  document.addEventListener("astro:page-load", initShareLinks);
 </script>

--- a/src/features/blog/scripts/progressBar.ts
+++ b/src/features/blog/scripts/progressBar.ts
@@ -1,7 +1,13 @@
+// 같은 페이지에서 직접 호출 + astro:page-load로 이중 호출돼도 scroll/resize 리스너가
+// 중복 등록되지 않도록 하는 가드. astro:before-swap에서 해제돼 다음 페이지에서 재초기화된다.
+let isActive = false;
+
 /**
  * Creates and manages a reading progress indicator at the top of the page
  */
 export function initializeProgressBar(): void {
+  if (isActive) return;
+  isActive = true;
   createProgressBar();
   updateScrollProgress();
 }
@@ -93,6 +99,7 @@ function updateScrollProgress(): void {
     "astro:before-swap",
     () => {
       controller.abort();
+      isActive = false;
       const container = document.getElementById("reading-progress-container");
       if (container) container.remove();
     },

--- a/src/layouts/components/Header/Navigation.astro
+++ b/src/layouts/components/Header/Navigation.astro
@@ -157,28 +157,36 @@ const menuItemBase =
 </nav>
 
 <script>
+  // 핸들러가 클로저 대신 매번 현재 페이지 DOM을 조회하도록 하는 헬퍼.
+  // View Transitions 스왑으로 교체된 옛 노드(detached)를 참조하지 않기 위함.
+  function getMenuElements() {
+    return {
+      menuBtn: document.querySelector<HTMLButtonElement>("[data-menu-btn]"),
+      menuItems: document.querySelector<HTMLUListElement>("[data-menu-items]"),
+    };
+  }
+
+  function openMenu() {
+    const { menuBtn, menuItems } = getMenuElements();
+    menuItems?.setAttribute("data-state", "open");
+    menuBtn?.setAttribute("aria-expanded", "true");
+    menuBtn?.setAttribute("aria-label", "메뉴 닫기");
+  }
+
+  function closeMenu() {
+    const { menuBtn, menuItems } = getMenuElements();
+    menuItems?.setAttribute("data-state", "closed");
+    menuBtn?.setAttribute("aria-expanded", "false");
+    menuBtn?.setAttribute("aria-label", "메뉴 열기");
+  }
+
   function toggleNav() {
-    const menuBtn =
-      document.querySelector<HTMLButtonElement>("[data-menu-btn]");
-    const menuItems =
-      document.querySelector<HTMLUListElement>("[data-menu-items]");
+    const { menuBtn } = getMenuElements();
+    if (!menuBtn) return;
 
-    if (!menuBtn || !menuItems) return;
-
+    // 버튼은 스왑마다 새 DOM으로 교체되므로 dataset 가드가 페이지당 1회 바인딩을 보장
     if (menuBtn.dataset.toggleNavSetup) return;
     menuBtn.dataset.toggleNavSetup = "true";
-
-    function openMenu() {
-      menuItems?.setAttribute("data-state", "open");
-      menuBtn?.setAttribute("aria-expanded", "true");
-      menuBtn?.setAttribute("aria-label", "메뉴 닫기");
-    }
-
-    function closeMenu() {
-      menuItems?.setAttribute("data-state", "closed");
-      menuBtn?.setAttribute("aria-expanded", "false");
-      menuBtn?.setAttribute("aria-label", "메뉴 열기");
-    }
 
     // 메뉴 버튼 클릭
     menuBtn.addEventListener("click", e => {
@@ -190,37 +198,43 @@ const menuItemBase =
         openMenu();
       }
     });
-
-    // 외부 클릭 시 닫기
-    document.addEventListener("click", e => {
-      const isOpen = menuBtn?.getAttribute("aria-expanded") === "true";
-      if (!isOpen) return;
-
-      const target = e.target as Node;
-      if (!menuItems?.contains(target) && !menuBtn?.contains(target)) {
-        closeMenu();
-      }
-    });
-
-    // Escape 키로 닫기
-    document.addEventListener("keydown", e => {
-      if (
-        e.key === "Escape" &&
-        menuBtn?.getAttribute("aria-expanded") === "true"
-      ) {
-        closeMenu();
-        menuBtn?.focus();
-      }
-    });
-
-    // 데스크톱 전환 시 상태 초기화
-    const desktopQuery = window.matchMedia("(min-width: 640px)");
-    desktopQuery.addEventListener("change", (e: MediaQueryListEvent) => {
-      if (e.matches) {
-        closeMenu();
-      }
-    });
   }
+
+  // 아래 리스너들의 타겟(document, MediaQueryList)은 스왑에도 살아남는 영속 객체라,
+  // toggleNav 안에서 등록하면 페이지 전환마다 누적된다. 모듈 스크립트는 세션당
+  // 1회만 실행되므로 최상위에서 한 번만 등록한다.
+
+  // 외부 클릭 시 닫기
+  document.addEventListener("click", e => {
+    const { menuBtn, menuItems } = getMenuElements();
+    const isOpen = menuBtn?.getAttribute("aria-expanded") === "true";
+    if (!isOpen) return;
+
+    const target = e.target as Node;
+    if (!menuItems?.contains(target) && !menuBtn?.contains(target)) {
+      closeMenu();
+    }
+  });
+
+  // Escape 키로 닫기
+  document.addEventListener("keydown", e => {
+    const { menuBtn } = getMenuElements();
+    if (
+      e.key === "Escape" &&
+      menuBtn?.getAttribute("aria-expanded") === "true"
+    ) {
+      closeMenu();
+      menuBtn?.focus();
+    }
+  });
+
+  // 데스크톱 전환 시 상태 초기화
+  const desktopQuery = window.matchMedia("(min-width: 640px)");
+  desktopQuery.addEventListener("change", (e: MediaQueryListEvent) => {
+    if (e.matches) {
+      closeMenu();
+    }
+  });
 
   toggleNav();
   document.addEventListener("astro:after-swap", toggleNav);

--- a/src/layouts/components/Navigation/BackToTopButton.astro
+++ b/src/layouts/components/Navigation/BackToTopButton.astro
@@ -47,11 +47,20 @@ import { Icon } from "astro-icon/components";
     if (!rootElement || !btnContainer || !backToTopBtn || !progressIndicator)
       return;
 
+    // data-astro-rerun으로 스왑마다 재실행되므로, 이전 실행이 document에 남긴
+    // 리스너는 astro:before-swap에서 abort로 일괄 해제한다 (progressBar.ts와 동일 패턴)
+    const controller = new AbortController();
+    const { signal } = controller;
+
     // Attach click event handler for back-to-top button
-    backToTopBtn.addEventListener("click", () => {
-      document.body.scrollTop = 0; // For Safari
-      document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
-    });
+    backToTopBtn.addEventListener(
+      "click",
+      () => {
+        document.body.scrollTop = 0; // For Safari
+        document.documentElement.scrollTop = 0; // For Chrome, Firefox, IE and Opera
+      },
+      { signal }
+    );
 
     // Handle button visibility according to scroll position
     let lastVisible = null;
@@ -77,14 +86,22 @@ import { Icon } from "astro-icon/components";
     }
 
     let ticking = false;
-    document.addEventListener("scroll", () => {
-      if (!ticking) {
-        window.requestAnimationFrame(() => {
-          handleScroll();
-          ticking = false;
-        });
-        ticking = true;
-      }
+    document.addEventListener(
+      "scroll",
+      () => {
+        if (!ticking) {
+          window.requestAnimationFrame(() => {
+            handleScroll();
+            ticking = false;
+          });
+          ticking = true;
+        }
+      },
+      { passive: true, signal }
+    );
+
+    document.addEventListener("astro:before-swap", () => controller.abort(), {
+      once: true,
     });
   }
   backToTop();


### PR DESCRIPTION
## Description

View Transitions(ClientRouter) 환경에서 **페이지 스왑에도 살아남는 영속 타겟(`document`, `MediaQueryList`)에 페이지 수명 코드가 리스너를 계속 추가**해 발생하던 메모리 누수 4건을 일괄 수정합니다. BackToTopButton 누수 보고를 계기로 `addEventListener` 전 사용처(39곳)와 타이머/옵저버를 전수 조사해 동류 누수 3건을 추가 확정했습니다.

| # | 파일 | 증상 | 수정 |
|---|------|------|------|
| 1 | `BackToTopButton.astro` | `data-astro-rerun` 재실행마다 document scroll 리스너 누적, detached 노드 클로저 보유 (글 스왑당 +1) | `AbortController` + `astro:before-swap`에서 abort, `passive: true` |
| 2 | `Header/Navigation.astro` | `astro:after-swap`마다 document click/keydown + matchMedia change 누적 — 멱등 가드가 스왑마다 교체되는 버튼 dataset이라 무효 (**전 페이지** 스왑당 +3) | 영속 타겟 리스너를 모듈 최상위로 호이스트(세션당 1회 등록), 핸들러는 매번 fresh query |
| 3 | `ShareLinks.astro` | 모듈 스코프 `const`가 첫 글의 detached 버튼 트리를 세션 내내 보유 + **두 번째 글부터 공유(URL 복사) 버튼 무반응(기능 버그)** | init 함수화 + `astro:page-load` 재초기화 + dataset 가드 |
| 4 | `progressBar.ts` | 초기 로드 시 직접 호출 + `astro:page-load` 이중 실행으로 scroll 리스너 2개 (첫 스왑에서 자가 치유되는 bounded 문제) | `isActive` 멱등 가드, before-swap에서 리셋 |

조사 결과 나머지(presentationMode, scrollSaver, ThemeToggle, Layout 테마 스크립트, copyButton/headingLinks, useTheme, search, BackButton/Main/index, PdfDownloadButton)는 기존 가드/cleanup이 유효해 수정 불필요로 확인했습니다.

### 검증 (TDD)

- 신규 **`e2e/listener-leak.spec.ts`**: `page.addInitScript`로 `EventTarget.prototype`을 래핑해 (타겟:타입)별 리스너 Set을 추적(AbortSignal abort 포함). 글↔글 왕복 6회 스왑 후 리스너 수가 **첫 진입과 동일**함을 단언하는 불변량 테스트 — 절대값 비교가 아니라 다른 컴포넌트 변경에 영향받지 않습니다. 프로덕션 코드에는 테스트용 코드 없음
- **수정 전 red** (버그 재현 증거): `document:click 3→9`, `document:keydown 3→9`, `document:scroll 3→8`, `mql:change 2→8` / 공유 버튼은 두 번째 글에서 무반응
- **수정 후 green**: 전체 E2E **42/42 통과** (기존 continue-reading·heading-links·og-image·presentation-mode 포함, 회귀 없음)
- `pnpm lint` / `astro check` / `pnpm build` 통과, dist 정적 출력물에 수정 반영 grep 확인

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

같은 부류의 누수지만 컴포넌트 성격에 따라 처방을 달리했습니다:

- **BackToTopButton**: 글→글 스왑 시 동일 인라인 스크립트는 스킵되므로 `data-astro-rerun` 유지가 필수 → per-run `AbortController` + before-swap abort (`progressBar.ts`의 기존 패턴 재사용). 전역 위임 방식은 글 전용 컴포넌트라 비-글 페이지에 데드 웨이트가 남고, `lastVisible` 상태가 페이지 간 살아남아 "이어 읽기" 스크롤 복원과 충돌할 수 있어 배제
- **Navigation**: 전 페이지 공통 헤더 + 모듈 스크립트는 세션당 1회 실행 → 한 번만 등록하고 핸들러가 fresh query 하는 쪽이 스왑마다 abort/재등록하는 것보다 단순 (ThemeToggle의 위임 철학과 동일)
- 리스너 카운팅에 `getEventListeners`는 CDP 전용이라 사용 불가 → `addInitScript` 스텁으로 동작 기반 검증

## Related Issue

없음 (세션 내 코드 리뷰에서 발견)
