### PR TITLE
refactor(config): Astro 6.4 markdown.processor 마이그레이션 - deprecation 경고 해소

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,9 +10,10 @@ Caesiumy's personal blog website built with Astro and AstroPaper template. This 
 
 ### AstroPaper Template
 - **Template**: [AstroPaper v5.5.0](https://github.com/satnaing/astro-paper)
-- **Framework**: Astro v5.12.0 (SSG)
-- **Styling**: TailwindCSS v4.1.11
-- **Type Checking**: TypeScript v5.8.3
+- **Framework**: Astro v6 (SSG) — exact versions live in `package.json`
+- **Markdown**: remark/rehype plugins are passed via `markdown.processor: unified({...})` from `@astrojs/markdown-remark` (Astro 6.4+ style, see `astro.config.ts`)
+- **Styling**: TailwindCSS v4
+- **Type Checking**: TypeScript v6
 - **Search**: Pagefind (static search)
 
 ### Core Features
@@ -65,16 +66,19 @@ CaesiumY.github.io/
 
 ### Blog Posts
 - **Location**: `contents/blog/`
-- **Format**: Markdown/MDX
-- **Frontmatter Schema**:
+- **Format**: Markdown (no MDX integration; loader matches `**/[^_]*.md`)
+- **Frontmatter Schema** (source of truth: `src/content.config.ts`):
 ```yaml
-title: "Post title"
-description: "Post description"
-pubDate: 2025-01-01
-updatedDate: 2025-01-02  # Optional
-heroImage: "/hero.jpg"    # Optional
-draft: false             # Default: false
-tags: ["tag1", "tag2"]   # Optional
+title: "Post title"                # Required
+description: "Post description"    # Required
+pubDatetime: 2025-01-01T09:00:00Z  # Required (ISO datetime)
+modDatetime: 2025-01-02T09:00:00Z  # Optional
+featured: false                    # Optional
+draft: false                       # Optional
+tags: ["tag1", "tag2"]             # Default: ["others"]
+ogImage: "./og-image.png"          # Optional (same-folder image or URL string)
+series: "Series name"              # Optional
+canonicalURL: "https://..."        # Optional
 ```
 
 ### Blog Images

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, envField } from "astro/config";
+import { unified } from "@astrojs/markdown-remark";
 import tailwindcss from "@tailwindcss/vite";
 import sitemap from "@astrojs/sitemap";
 import react from "@astrojs/react";
@@ -31,16 +32,20 @@ export default defineConfig({
     }),
   ],
   markdown: {
-    remarkPlugins: [
-      [remarkToc, { heading: "(table[ -]of[ -])?contents?|toc|목차" }],
-      [
-        remarkCollapse,
-        {
-          test: /^(Table of contents|목차)$/,
-          summary: "목차 보기",
-        },
+    // remark/rehype 플러그인은 Astro 6.4부터 unified() 프로세서로 전달해야 함.
+    // (markdown.remarkPlugins/rehypePlugins/remarkRehype는 deprecated)
+    processor: unified({
+      remarkPlugins: [
+        [remarkToc, { heading: "(table[ -]of[ -])?contents?|toc|목차" }],
+        [
+          remarkCollapse,
+          {
+            test: /^(Table of contents|목차)$/,
+            summary: "목차 보기",
+          },
+        ],
       ],
-    ],
+    }),
     shikiConfig: {
       // For more themes, visit https://shiki.style/themes
       themes: { light: "min-light", dark: "night-owl" },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:debug": "playwright test --debug"
   },
   "dependencies": {
+    "@astrojs/markdown-remark": "^7.2.0",
     "@astrojs/react": "^5.0.7",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/markdown-remark':
+        specifier: ^7.2.0
+        version: 7.2.0
       '@astrojs/react':
         specifier: ^5.0.7
         version: 5.0.7(@types/node@25.6.0)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(jiti@2.7.0)(lightningcss@1.32.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(yaml@2.8.3)

--- a/src/features/blog/scripts/presentationMode.ts
+++ b/src/features/blog/scripts/presentationMode.ts
@@ -15,7 +15,7 @@
  * **반드시 일치**해야 함. 양쪽이 어긋나면 `<details>` 블록을 찾지 못해 목차 슬라이드가
  * 조용히 누락됨(에러 없이 H2 섹션들만 렌더). astro.config.ts 수정 시 여기도 함께 갱신 필요.
  *
- * 참고 경로: astro.config.ts → markdown.remarkPlugins → remarkCollapse의 `summary` 필드
+ * 참고 경로: astro.config.ts → markdown.processor → unified()의 remarkPlugins → remarkCollapse의 `summary` 필드
  */
 const AGENDA_SUMMARY_TEXT = "목차 보기";
 /**


### PR DESCRIPTION
## Description

`pnpm dev`/`pnpm build` 시 매번 출력되던 Astro deprecation 경고를 해소합니다.

> [astro] `markdown.remarkPlugins`, `markdown.rehypePlugins`, and `markdown.remarkRehype` are deprecated. Pass them to `unified({...})` from `@astrojs/markdown-remark` directly instead.

**변경 1 — markdown 설정 마이그레이션** (`2df2fea`)
- `markdown.remarkPlugins` 배열을 Astro 6.4의 권장 방식인 `markdown.processor: unified({ remarkPlugins: [...] })`로 이전
- `@astrojs/markdown-remark@^7.2.0`을 직접 의존성으로 추가 (astro 6.4.3이 내부에서 쓰는 버전과 동일 — 중복 설치 없음)
- remark-toc/remark-collapse 플러그인과 옵션(`summary: "목차 보기"` 포함)은 한 글자도 변경 없음
- `shikiConfig`는 deprecated 대상이 아니므로 `markdown` 레벨에 유지
- `presentationMode.ts`의 `AGENDA_SUMMARY_TEXT` 상수 주석이 가리키는 설정 참조 경로 갱신

**변경 2 — CLAUDE.md 현행화** (`5672dfe`)
- 버전 표기를 실제(package.json)와 일치하는 메이저 수준으로 갱신: Astro v5.12.0→v6, TailwindCSS v4.1.11→v4, TypeScript v5.8.3→v6
- frontmatter 스키마를 `content.config.ts` 실제 정의와 동기화 (`pubDate`→`pubDatetime`, `heroImage`→`ogImage` 등 — 기존 표기대로 글을 쓰면 zod 검증 실패로 빌드가 깨지는 상태였음)
- MDX 미사용 사실 반영

## Types of changes

- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [x] Others (deprecated 설정 마이그레이션 + 문서 현행화)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [x] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

**출력 불변 검증** — Astro는 레거시 옵션을 내부적으로 동일한 `unified()` 프로세서로 변환해 실행해왔으므로, 마이그레이션 후 출력은 완전히 동일해야 합니다. 실제로:

1. **마이그레이션 전후 `dist/` HTML 166개 전부 SHA256 해시 일치** — 목차(remark-collapse `<details>` 블록)와 Shiki 코드 하이라이팅이 바이트 단위로 불변
2. `astro check` 0 errors / 0 warnings (타입 정의 없는 remark-collapse도 `unified()` 시그니처와 호환)
3. 빌드 출력에서 deprecation 경고 0건
4. **Playwright e2e 37개 전부 통과** — `presentation-mode.spec.ts`의 목차 슬라이드 구조(`<summary>목차 보기</summary>` 의존) 회귀 없음

참고: 로컬 Windows에서 `pnpm build`의 마지막 `cp -r dist/pagefind public/` 단계는 cmd에 `cp`가 없어 실패하는데, 이는 마이그레이션 전에도 동일한 기존 환경 이슈입니다 (Linux CI에는 영향 없음).

## Related Issue

Closes: N/A
