### PR TITLE
docs: agents-md-optimizer 스킬 도입 + CLAUDE.md/AGENTS.md 최적화 (−65%)

### DIFF
--- a/.claude/skills/agents-md-optimizer/SKILL.md
+++ b/.claude/skills/agents-md-optimizer/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: agents-md-optimizer
+description: "Optimize agent context files (AGENTS.md, CLAUDE.md, .cursorrules, .windsurfrules, .github/copilot-instructions.md, codex.md, etc.) using Addy Osmani's agents-md methodology. Triggers: 'optimize CLAUDE.md', 'streamline CLAUDE.md', 'agents-md', 'discoverability filter', 'add gotchas', 'optimize AGENTS.md', 'optimize context file', 'CLAUDE.md 최적화', 'CLAUDE.md 줄이기', 'CLAUDE.md 다이어트', 'optimize .cursorrules', 'optimize .windsurfrules', 'optimize copilot-instructions', 'optimize codex.md'."
+allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
+---
+
+# Agents-MD Optimizer
+
+Optimize agent context files (CLAUDE.md, AGENTS.md, .cursorrules, etc.) by applying the discoverability filter: remove information agents can discover from code, keep only non-discoverable operational knowledge (gotchas, landmines, non-standard conventions), and mine source code for undocumented gotchas.
+
+Research shows redundant context (directory trees, data flow diagrams) degrades agent performance by 15-20%, while human-authored operational knowledge reduces runtime by ~28%.
+
+## Flag Parsing
+
+Parse `$ARGUMENTS` for optional flags:
+
+| Flag | Effect |
+|------|--------|
+| `--dry-run` | Analyze and show diff without modifying the file |
+| `--report-only` | Output statistics and classification table only |
+| `--path <path>` | Target file path (see auto-detection below) |
+| `--help` | Display usage and exit |
+
+If `--help` is present, display available flags and a brief description of the workflow, then stop.
+
+## Workflow
+
+### Phase 0: Setup
+
+**Language Detection**: Detect the user's language from conversation history. Present all analysis results and messages in the user's language.
+
+**Target File Resolution** (when `--path` is not specified):
+
+Search for the first existing file in this priority order:
+1. `AGENTS.md`
+2. `CLAUDE.md`
+3. `.cursorrules`
+4. `CURSOR.md`
+5. `.github/copilot-instructions.md`
+6. `.windsurfrules`
+7. `codex.md`
+
+If none found, ask the user to specify the target file path.
+
+**Small File Check**: If the target file has fewer than 20 lines, inform the user that the file is already minimal and optimization is unnecessary. Stop unless the user explicitly requests to proceed.
+
+### Step 1: Baseline Analysis
+
+Read the target file. Collect line statistics.
+
+**Script Location**: Find the line-count script by searching for it:
+
+```bash
+# Search in common skill installation paths
+SCRIPT_PATH=$(find ~/.claude/skills ~/.codex/skills ~/.cursor/skills ~/skills 2>/dev/null -path "*/agents-md-optimizer/scripts/line-count.mjs" | head -1)
+if [ -z "$SCRIPT_PATH" ]; then
+  # Fallback: search in current directory
+  SCRIPT_PATH=$(find . -path "*/agents-md-optimizer/scripts/line-count.mjs" 2>/dev/null | head -1)
+fi
+```
+
+Run the script if found:
+
+```bash
+node "$SCRIPT_PATH" '<TARGET_PATH>'
+```
+
+**Fallback** (if script not found): Count lines manually using Bash:
+
+```bash
+wc -l '<TARGET_PATH>'
+grep -c '^##' '<TARGET_PATH>'
+```
+
+Then classify each `##`/`###` section into one of three categories:
+
+| Category | Meaning | Action |
+|----------|---------|--------|
+| `discoverable` | Agent can find this via Glob/Grep/Read within 10 seconds | Remove |
+| `operational` | Non-discoverable, operationally significant | Keep |
+| `verbose` | Operational knowledge but overly detailed | Compress |
+
+To classify, **actually read the source files** referenced in each section. Verify whether the information is truly discoverable. Detailed classification criteria are in [`references/methodology.md`](references/methodology.md).
+
+Present results as a table:
+
+```
+## Baseline Analysis — <filename>
+
+Total: XXX lines (YY sections)
+
+| Section | Lines | Category | Rationale |
+|---------|-------|----------|-----------|
+| Directory Structure | 63 | discoverable | Glob **/* reveals this instantly |
+| Design Rules | 8 | operational | Non-standard constraints, not in code |
+| Config & State | 24 | verbose | Operational but compressible to ~6 lines |
+
+Removal candidates: XX lines (XX%)
+```
+
+If `--report-only`, stop here.
+
+### Step 2: Gotcha Mining
+
+Scan project source code to find non-obvious operational knowledge missing from the target file. Use the systematic checklist in [`references/gotcha-mining.md`](references/gotcha-mining.md).
+
+Key Grep patterns to run on the codebase:
+
+```
+MUST|WARNING|HACK|TODO|FIXME          → developer-flagged gotchas
+catch.*exit\(0\)|process\.exit        → error exit policies
+setTimeout|setInterval|deadline       → timing constraints
+=== null|== null|delete result        → implicit semantics
+process\.platform|/proc/version       → platform detection quirks
+cooldown|throttle|lastNotified        → rate limiting scope
+```
+
+Present findings:
+
+```
+## Discovered Gotchas
+
+| # | Category | Description | Source | Already documented? |
+|---|----------|-------------|--------|---------------------|
+| 1 | Timing | 5s→4s→2s budget | _common.mjs:21,52 | No → Add |
+| 2 | Implicit | null = key deletion | config.mjs:157 | No → Add |
+```
+
+### Step 3: Generate Optimized File
+
+Use AskUserQuestion to confirm before modifying:
+
+> Based on the analysis:
+> - **Remove**: X lines of discoverable content (Y sections)
+> - **Compress**: X lines → ~Y lines (Z sections)
+> - **Add**: X new gotcha items
+>
+> Options:
+> 1. **Apply all** — Remove discoverable, compress verbose, add gotchas
+> 2. **Item by item** — Review each change individually
+> 3. **Cancel** — No changes
+
+Apply the selected changes using Edit (prefer surgical edits over full rewrite).
+
+If `--dry-run`, show the diff but do not write.
+
+**Structure for optimized file** (recommended section order):
+1. Project description (1-2 lines)
+2. Development Commands
+3. Design Rules (non-negotiable constraints)
+4. Gotchas & Landmines (categorized subsections)
+5. Conventions (non-standard project patterns)
+6. Version/Release Management
+7. Testing
+
+Detailed anti-pattern examples with before/after are in [`references/anti-patterns.md`](references/anti-patterns.md).
+
+### Step 4: Verification
+
+Re-run statistics (using the same script or fallback method from Step 1) and present before/after comparison:
+
+```
+## Optimization Results
+
+| Metric | Before | After | Change |
+|--------|--------|-------|--------|
+| Total lines | 182 | 90 | -51% |
+| Discoverable lines | 80 | 0 | Removed |
+| Operational lines | 60 | 55 | Kept |
+| Gotcha items | 0 | 25 | Added |
+
+Discoverability filter: all remaining lines pass "not discoverable from code" check.
+```
+
+## Reference Files
+
+- **[`references/methodology.md`](references/methodology.md)** — Discoverability filter decision tree, category classification criteria, compression techniques, efficiency research data
+- **[`references/anti-patterns.md`](references/anti-patterns.md)** — 6 anti-pattern catalog with real before/after examples
+- **[`references/gotcha-mining.md`](references/gotcha-mining.md)** — 8-category mining checklist with Grep patterns and source code analysis techniques

--- a/.claude/skills/agents-md-optimizer/SKILL.md
+++ b/.claude/skills/agents-md-optimizer/SKILL.md
@@ -51,15 +51,17 @@ Read the target file. Collect line statistics.
 **Script Location**: Find the line-count script by searching for it:
 
 ```bash
-# Search in common skill installation paths
-SCRIPT_PATH=$(find ~/.claude/skills ~/.codex/skills ~/.cursor/skills ~/skills 2>/dev/null -path "*/agents-md-optimizer/scripts/line-count.mjs" | head -1)
-if [ -z "$SCRIPT_PATH" ]; then
-  # Fallback: check known relative paths first before running a heavy find
-  if [ -f "./.claude/skills/agents-md-optimizer/scripts/line-count.mjs" ]; then
-    SCRIPT_PATH="./.claude/skills/agents-md-optimizer/scripts/line-count.mjs"
-  elif [ -f "./.agents/skills/agents-md-optimizer/scripts/line-count.mjs" ]; then
-    SCRIPT_PATH="./.agents/skills/agents-md-optimizer/scripts/line-count.mjs"
-  else
+# Project-local vendored copy takes precedence over global installs
+# (a stale global version must not shadow the patched local one)
+if [ -f "./.claude/skills/agents-md-optimizer/scripts/line-count.mjs" ]; then
+  SCRIPT_PATH="./.claude/skills/agents-md-optimizer/scripts/line-count.mjs"
+elif [ -f "./.agents/skills/agents-md-optimizer/scripts/line-count.mjs" ]; then
+  SCRIPT_PATH="./.agents/skills/agents-md-optimizer/scripts/line-count.mjs"
+else
+  # Search common global skill installation paths
+  SCRIPT_PATH=$(find ~/.claude/skills ~/.codex/skills ~/.cursor/skills ~/skills 2>/dev/null -path "*/agents-md-optimizer/scripts/line-count.mjs" | head -1)
+  if [ -z "$SCRIPT_PATH" ]; then
+    # Last resort: search the project tree, skipping node_modules
     SCRIPT_PATH=$(find . -name "node_modules" -prune -o -path "*/agents-md-optimizer/scripts/line-count.mjs" -print 2>/dev/null | head -1)
   fi
 fi

--- a/.claude/skills/agents-md-optimizer/SKILL.md
+++ b/.claude/skills/agents-md-optimizer/SKILL.md
@@ -4,6 +4,16 @@ description: "Optimize agent context files (AGENTS.md, CLAUDE.md, .cursorrules, 
 allowed-tools: [Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion]
 ---
 
+<!--
+  Vendored from https://github.com/CaesiumY/agents-md-optimizer
+  Local patches not yet upstreamed (battle-tested in PR #78):
+    - scripts/line-count.mjs: CRLF-safe split, trailing-newline strip,
+      inclusive +1 section line counts, bounds/fence/H1 convention comments
+    - SKILL.md (this file): script resolution prefers the project-local
+      vendored copy; find fallback prunes node_modules
+  When syncing from upstream, upstream these first or re-apply them.
+-->
+
 # Agents-MD Optimizer
 
 Optimize agent context files (CLAUDE.md, AGENTS.md, .cursorrules, etc.) by applying the discoverability filter: remove information agents can discover from code, keep only non-discoverable operational knowledge (gotchas, landmines, non-standard conventions), and mine source code for undocumented gotchas.

--- a/.claude/skills/agents-md-optimizer/SKILL.md
+++ b/.claude/skills/agents-md-optimizer/SKILL.md
@@ -54,8 +54,14 @@ Read the target file. Collect line statistics.
 # Search in common skill installation paths
 SCRIPT_PATH=$(find ~/.claude/skills ~/.codex/skills ~/.cursor/skills ~/skills 2>/dev/null -path "*/agents-md-optimizer/scripts/line-count.mjs" | head -1)
 if [ -z "$SCRIPT_PATH" ]; then
-  # Fallback: search in current directory
-  SCRIPT_PATH=$(find . -path "*/agents-md-optimizer/scripts/line-count.mjs" 2>/dev/null | head -1)
+  # Fallback: check known relative paths first before running a heavy find
+  if [ -f "./.claude/skills/agents-md-optimizer/scripts/line-count.mjs" ]; then
+    SCRIPT_PATH="./.claude/skills/agents-md-optimizer/scripts/line-count.mjs"
+  elif [ -f "./.agents/skills/agents-md-optimizer/scripts/line-count.mjs" ]; then
+    SCRIPT_PATH="./.agents/skills/agents-md-optimizer/scripts/line-count.mjs"
+  else
+    SCRIPT_PATH=$(find . -name "node_modules" -prune -o -path "*/agents-md-optimizer/scripts/line-count.mjs" -print 2>/dev/null | head -1)
+  fi
 fi
 ```
 

--- a/.claude/skills/agents-md-optimizer/references/anti-patterns.md
+++ b/.claude/skills/agents-md-optimizer/references/anti-patterns.md
@@ -1,0 +1,176 @@
+# Anti-Pattern Catalog
+
+Patterns commonly found in CLAUDE.md files that should be removed or compressed.
+Each pattern is illustrated with real examples from the dding-dong project optimization (182 → 90 lines, 51% reduction).
+
+## Anti-Pattern #1: Directory Structure Tree
+
+**Why discoverable:** `ls -la`, `Glob **/*`, or `tree` reveals the entire structure instantly.
+
+**Before (63 lines):**
+```
+### Directory Structure
+
+hooks/                 # Claude Code hook entry points (.mjs)
+  hooks.json           # Hook registration manifest
+  _common.mjs          # Shared runHook() utility
+  notification.mjs     # Notification hook → input.required
+  stop.mjs             # Stop hook → task.complete
+skills/
+  dd-config/
+    SKILL.md           # /dding-dong:dd-config - settings management
+    scripts/
+      config-get.mjs   # Config key reader
+      config-set.mjs   # Config key writer
+  ...                  # (50+ more lines)
+```
+
+**After:** Entire section deleted. Zero lines.
+
+**Exception:** Keep a directory note only if the structure is *counter-intuitive* or violates convention (e.g., "Tests live in `src/` next to source files, not in `test/`").
+
+## Anti-Pattern #2: Data Flow Diagram
+
+**Why discoverable:** Following `import` chains from entry points reveals the exact flow.
+
+**Before (16 lines):**
+```
+### Data Flow
+
+Hook event → hooks/*.mjs
+  → _common.mjs runHook(eventType, options)
+    → stdin parse (JSON event)
+    → scripts/notify.mjs notify(eventType, context)
+      → loadConfig(cwd)
+      → config.enabled check
+      → isQuietHours() check
+      → loadState()
+      → isCoolingDown() check
+      → playSound() + sendNotification()
+      → saveState()
+    → optional stdout response
+```
+
+**After:** Entire section deleted. Zero lines.
+
+**Exception:** Keep if the flow has a non-obvious *constraint* (e.g., "playSound and sendNotification must run in parallel via Promise.allSettled, never sequential").
+
+## Anti-Pattern #3: Tech Stack / "X uses Y" Descriptions
+
+**Why discoverable:** Import statements, `package.json`, and file extensions are self-documenting.
+
+**Before:**
+```
+- `player.mjs` uses `spawn` from `node:child_process` for audio playback
+- `notifier.mjs` uses `execFileSync` for OS notifications
+- All scripts use ESM with `.mjs` extension
+```
+
+**After:** Only the non-obvious rule survives:
+```
+- **ESM only**: All scripts use `.mjs` extension with `import`/`export` syntax.
+```
+
+This survives because it's a *project convention* that could be violated (someone might add a `.js` file), not a description of what exists.
+
+## Anti-Pattern #4: Config Path Listings
+
+**Why discoverable:** Config modules export path constants; reading the module reveals all paths.
+
+**Before (24 lines):**
+```
+### Config & State Files
+
+Config is loaded via 5-stage merge (later stages override earlier):
+1. **Default** — hardcoded `DEFAULT_CONFIG` in `config.mjs`
+2. **Global** — `~/.config/dding-dong/config.json`
+3. **Project** — `.dding-dong/config.json` (team-shared, committed)
+4. **Project Local** — `.dding-dong/config.local.json` (personal override, gitignored)
+5. **Env vars** — `DDING_DONG_ENABLED`, `DDING_DONG_VOLUME`, ...
+
+Other paths:
+- State: `~/.config/dding-dong/.state.json`
+- Project sound packs: `.dding-dong/packs/<pack-name>/manifest.json`
+- User sound packs: `~/.config/dding-dong/packs/<pack-name>/manifest.json`
+- Backup files: `<config-path>.backup.<YYYYMMDD_HHMMSS>` (max 3)
+
+#### `_meta` field convention
+The `_meta` field in the global config stores setup metadata:
+{ "_meta": { "setupCompleted": true, ... } }
+- Stored in: Global config only
+- Merge behavior: Isolated from deepMerge
+- Usage: doctor skill checks _meta.setupCompleted
+```
+
+**After (6 lines in Gotchas > Config):**
+```
+### Config
+- 5-stage merge (later wins): Default ← Global ← Project ← Local ← env vars
+- `_meta`: extracted before deepMerge, re-attached after. Global-only. Cannot be polluted by project config
+- `null` in deepMerge = key deletion. `{ "sound": null }` → removes the sound key entirely. To disable, use `{ "sound": { "enabled": false } }`
+- Project/Local scopes store diff-only overrides (not full snapshots)
+- `saveConfig` runs round-trip `JSON.parse` validation. On failure, auto-restores from backup
+- Backups: max 3 per config file, oldest auto-deleted
+```
+
+The paths are discoverable; the *behaviors* (null deletion, _meta isolation, diff-only, round-trip validation) are not.
+
+## Anti-Pattern #5: Cross-Platform Table
+
+**Why discoverable:** Platform detection code explicitly lists all platforms and their tools.
+
+**Before (9 lines):**
+```
+### Cross-Platform Strategy
+
+| Platform | Sound Playback | OS Notification |
+|----------|---------------|-----------------|
+| macOS    | `afplay`      | `osascript`     |
+| Linux    | `pw-play` > `paplay` > `ffplay` > `mpv` > `aplay` | `notify-send` |
+| WSL      | PowerShell `MediaPlayer` | `wsl-notify-send` > WinRT Toast > terminal bell |
+```
+
+**After (3 lines in Gotchas > Platform):**
+```
+### Platform
+- WSL detection: checks `/proc/version` for "microsoft" (case-insensitive). `process.platform` returns `"linux"` even on WSL
+- Linux audio priority: `pw-play` > `paplay` > `ffplay` > `mpv` > `aplay`
+- WSL notification priority: `wsl-notify-send` > WinRT PowerShell Toast > terminal bell
+```
+
+macOS entries are removed (standard, discoverable). WSL detection gotcha is added (non-obvious). Priority orders are kept (require reading implementation to determine order).
+
+## Anti-Pattern #6: Event Type Enumerations
+
+**Why discoverable:** Grep for event definitions in hooks.json or message files reveals all types.
+
+**Before:**
+```
+### Event Types
+
+`task.complete`, `task.error`*, `input.required`, `session.start`, `session.end`
+
+> *`task.error` is defined in config/messages but has no triggering hook.
+```
+
+**After (1 line in Gotchas > Events):**
+```
+### Events
+- `task.error`: defined in config/messages but has no triggering hook. Only testable via CLI test mode.
+```
+
+The enumeration is removed; only the *caveat* (no triggering hook) survives because it requires cross-referencing hooks.json with messages.mjs.
+
+## Decision Flowchart
+
+For each section in CLAUDE.md:
+
+```
+Is this information discoverable via ls/Glob/Grep/Read?
+├── Yes → DELETE the section
+├── No → Is it expressed concisely (≤3 lines)?
+│   ├── Yes → KEEP as-is
+│   └── No → COMPRESS to essential gotcha bullets
+└── Partially (fact exists but implication doesn't)
+    → REWRITE as a gotcha (state the non-obvious implication)
+```

--- a/.claude/skills/agents-md-optimizer/references/gotcha-mining.md
+++ b/.claude/skills/agents-md-optimizer/references/gotcha-mining.md
@@ -1,0 +1,181 @@
+# Gotcha Mining Checklist
+
+Systematic process for discovering non-obvious operational knowledge hidden in source code. Each category includes what to look for, Grep patterns, and examples from the dding-dong project.
+
+## Mining Process
+
+1. Identify the project's core modules (entry points, config, platform abstraction)
+2. For each module, scan using the category checklists below
+3. For each finding, ask: "Is this already in CLAUDE.md?" and "Would an agent get this wrong without being told?"
+4. Document findings with source file and line reference
+
+## Category 1: Timing & Ordering Constraints
+
+Hidden time budgets, sequencing requirements, and race conditions.
+
+**Grep patterns:**
+```
+setTimeout|setInterval|deadline|timeout|budget
+Promise\.race|Promise\.allSettled
+```
+
+**What to look for:**
+- Nested timeouts that create a timing budget (outer timeout minus inner timeout = remaining budget)
+- Operations that must complete within a time window
+- Specific ordering of async operations
+
+**dding-dong example:**
+- `hooks/_common.mjs`: hooks.json 5s timeout → internal safety timer 4s → stdin read 2s → only ~2s left for notify()
+- This timing *budget* is invisible from any single line of code — it emerges from the interaction of three separate timeouts
+
+## Category 2: Implicit Semantics
+
+Values that mean something unexpected, special-cased behavior.
+
+**Grep patterns:**
+```
+=== null|== null|delete .+\[|delete result
+deepMerge|Object\.assign|structuredClone
+```
+
+**What to look for:**
+- `null` used as a sentinel (deletion, reset, bypass)
+- Merge functions with special handling for specific values
+- Default values that override or get overridden unexpectedly
+
+**dding-dong example:**
+- `config.mjs:157`: `null` in deepMerge triggers `delete result[key]` — setting `{ "sound": null }` doesn't set sound to null, it *removes* the sound key entirely
+- Trap: a developer trying to "clear" a config value with null accidentally deletes the entire subtree
+
+## Category 3: Platform Detection Gotchas
+
+Cases where platform detection behaves non-obviously.
+
+**Grep patterns:**
+```
+process\.platform|os\.platform|/proc/version
+wsl|microsoft|darwin|win32
+```
+
+**What to look for:**
+- WSL reporting as "linux" in `process.platform`
+- Platform-specific paths or commands that differ from expectations
+- Detection methods that use file contents instead of standard APIs
+
+**dding-dong example:**
+- `platform.mjs:14`: WSL detected via `/proc/version` containing "microsoft" (case-insensitive), because `process.platform` returns `"linux"` on WSL
+- Without this gotcha, an agent would treat WSL as standard Linux and use wrong audio/notification tools
+
+## Category 4: Mandatory Response Contracts
+
+Entry points that MUST produce specific output or the system blocks.
+
+**Grep patterns:**
+```
+stdout\.write|process\.stdout|respond|response
+MUST|must write|must respond|required.*output
+```
+
+**What to look for:**
+- Hook handlers that must write to stdout (blocking callers await the response)
+- API endpoints with mandatory response shapes
+- IPC protocols requiring acknowledgment
+
+**dding-dong example:**
+- `hooks/_common.mjs`: stop hook MUST write `{}` to stdout — Claude Code waits for this response. Missing it halts execution
+- Safety net: `uncaughtException` handler writes the response before exiting, ensuring Claude never blocks
+
+## Category 5: Error Exit Policies
+
+Non-standard error handling where errors are intentionally swallowed.
+
+**Grep patterns:**
+```
+catch.*exit\(0\)|catch.*\{\s*\}|process\.exit\(0\)
+// ignore|// silent|// swallow
+```
+
+**What to look for:**
+- `exit(0)` in catch blocks (errors intentionally don't propagate)
+- Empty catch blocks with comments explaining why
+- Design decisions where failure of a subsystem must not affect the parent
+
+**dding-dong example:**
+- All hook catch blocks call `process.exit(0)` — notification failure must never block Claude Code
+- `detached: true` + `.unref()` pattern: audio processes are fire-and-forget to meet the 5s hook timeout
+
+## Category 6: Hidden Configuration Rules
+
+Configuration behaviors that aren't apparent from the config schema alone.
+
+**Grep patterns:**
+```
+_meta|\.meta|internal|private|reserved
+diff.only|override|merge.*before|merge.*after
+backup|restore|rollback
+```
+
+**What to look for:**
+- Fields extracted/re-attached around merge operations (isolation patterns)
+- Config scopes that store partial data (diffs vs snapshots)
+- Automatic backup/restore mechanisms
+
+**dding-dong example:**
+- `config.mjs:178-184,219`: `_meta` field extracted before deepMerge, re-attached after — prevents project config from overwriting global setup metadata
+- `config.mjs:227`: Project/Local scopes store diff-only overrides, not full config snapshots
+- `config.mjs:250-256`: Round-trip JSON.parse validation after save; on failure, auto-restores from backup
+
+## Category 7: Cooldown & Deduplication
+
+Rate limiting or deduplication logic with non-obvious scope.
+
+**Grep patterns:**
+```
+cooldown|throttle|debounce|rate.limit
+lastNotified|lastRun|lastExec|timestamp
+```
+
+**What to look for:**
+- Cooldowns that are global vs per-event vs per-source
+- Timestamps that prevent expected operations from firing
+- Edge cases where rapid successive events suppress each other
+
+**dding-dong example:**
+- `config.mjs:43`: Single global `cooldown_seconds: 3` with one `lastNotifiedAt` timestamp
+- Gotcha: a `task.complete` notification suppresses a `session.start` notification that follows within 3 seconds — the cooldown is global, not per-event-type
+
+## Category 8: Reserved / Unimplemented Features
+
+Defined interfaces with no actual implementation or trigger.
+
+**Grep patterns:**
+```
+TODO|FIXME|HACK|XXX|DEPRECATED
+reserved|future|placeholder|not.yet|unimplemented
+```
+
+**What to look for:**
+- Event types defined in config/messages but with no corresponding hook
+- API routes declared but not wired to handlers
+- Feature flags that are always false
+
+**dding-dong example:**
+- `task.error` event: defined in `DEFAULT_CONFIG.sound.events`, has messages in `messages.mjs`, but no hook in `hooks.json` triggers it
+- Only testable via CLI `test` mode. Reserved for future Claude Code error hook support
+
+## Mining Summary Template
+
+After scanning, organize findings in this format:
+
+```markdown
+## Discovered Gotchas
+
+| # | Category | Description | Source | In CLAUDE.md? |
+|---|----------|-------------|--------|---------------|
+| 1 | Timing | 5s→4s→2s budget leaves ~2s for notify() | _common.mjs:21,52 | No → Add |
+| 2 | Implicit | null = key deletion in deepMerge | config.mjs:157 | No → Add |
+| 3 | Platform | WSL detected via /proc/version, not process.platform | platform.mjs:14 | No → Add |
+| ... | ... | ... | ... | ... |
+```
+
+This table drives Step 3 (optimization) of the skill workflow.

--- a/.claude/skills/agents-md-optimizer/references/methodology.md
+++ b/.claude/skills/agents-md-optimizer/references/methodology.md
@@ -1,0 +1,110 @@
+# Discoverability Filter Methodology
+
+Based on Addy Osmani's [agents-md](https://addyosmani.com/blog/agents-md/) blog post and supporting research.
+
+## Core Principle
+
+> "Can the agent find this by reading the code? If yes, delete it."
+
+CLAUDE.md should contain only information that is:
+1. **Non-discoverable** — cannot be found by reading source code, running `ls`, or following imports
+2. **Operationally significant** — changes how the agent executes tasks
+3. **Impossible to guess** — not inferable from standard conventions
+
+## The 10-Second Rule
+
+For each line in CLAUDE.md, ask: "Can an agent discover this using Glob, Grep, or Read within 10 seconds?"
+
+- **Yes** → Mark as `discoverable` → Remove
+- **No, but the info is correct** → Mark as `operational` → Keep
+- **Partially** — the fact exists in code but the *implication* doesn't → Mark as `verbose` → Compress
+
+## Category Classification
+
+### Discoverable (Remove)
+
+Information agents find automatically through standard exploration:
+
+| Pattern | How Agent Discovers It |
+|---------|----------------------|
+| Directory structure trees | `ls -la`, `Glob **/*` |
+| Data flow diagrams | Follow `import`/`require` chains |
+| Tech stack descriptions | `package.json`, file extensions, imports |
+| "X uses Y" explanations | Import statements are self-documenting |
+| File-by-file descriptions | Reading the file itself is faster than reading about it |
+| Architecture overviews | Module boundaries visible from directory + imports |
+| Event/type enumerations | Grep for type definitions, enum values |
+| Config path listings | Constants in config modules |
+| Standard build steps | `package.json` scripts, `Makefile` targets |
+| Dependency relationships | `import` graph traversal |
+
+### Operational (Keep)
+
+Information that requires human experience to know:
+
+| Pattern | Why Not Discoverable |
+|---------|---------------------|
+| Timing constraints | Timeout values exist in code but their *budget allocation* across stages isn't obvious |
+| Mandatory response contracts | Code shows `stdout.write()` but not *why* it's critical (e.g., blocks Claude) |
+| Null semantics in merge | `delete result[key]` exists but the design choice that "null = deletion" is a gotcha |
+| Error exit policies | `exit(0)` in catch blocks exists but the rule "never block Claude" is a design decision |
+| Platform detection gotchas | Code checks `/proc/version` but the fact that `process.platform === "linux"` on WSL is a trap |
+| Cooldown scope decisions | Single timestamp exists but "global, not per-event" is a design choice |
+| Commit ordering conventions | No code enforces "feature commit first, then version bump" |
+| Non-standard tool choices | `uv` vs `pip`, `bun` vs `npm` — convention, not discoverable |
+| Reserved/unimplemented features | Defined in config but no hook exists — requires cross-referencing multiple files |
+
+### Verbose (Compress)
+
+Operational knowledge expressed in too many lines:
+
+**Indicators:**
+- Config merge explanation spanning 10+ lines → Compress to 1-line summary with stage order
+- Cross-platform table with obvious entries → Keep only non-obvious platforms (e.g., WSL)
+- Multi-paragraph explanations of backup behavior → Compress to "max N, auto-rotated"
+
+**Compression Techniques:**
+- **Table → bullet**: Convert multi-row tables to single-line `key: value` bullets
+- **Paragraph → condition-result**: "When X happens, Y occurs" in one line
+- **Enumeration → range**: "5 event types: ..." → Only mention the one with a caveat
+- **Section → subsection**: Promote to parent section's bullet point
+
+## Efficiency Data
+
+Research findings supporting this methodology:
+
+| Study | Finding |
+|-------|---------|
+| Lulla et al. (2026) | Human-authored AGENTS.md reduced wall-clock runtime by **28.64%** and token consumption by **16.58%** |
+| ETH Zurich | LLM-generated context files **reduced** task success by 2-3% while **increasing** cost by 20%+ |
+| Arize AI | Automated refinement of agent instructions achieved +5.19% accuracy improvement |
+
+Key insight: **Adding information can hurt performance.** Redundant context forces agents to process the same information twice, consuming tokens and increasing latency without improving accuracy.
+
+## The Pink Elephant Problem
+
+Mentioning a deprecated pattern anchors the model toward it. If CLAUDE.md says "Don't use the old auth module," the agent becomes more likely to reference it. Instead:
+- Delete mentions of deprecated code entirely
+- If the agent encounters it, it will ask or investigate — which is the correct behavior
+
+## Maintenance Philosophy
+
+> "AGENTS.md is a living list of codebase smells you haven't fixed yet, not a permanent configuration."
+
+Implications:
+- When a gotcha is fixed in code, remove it from CLAUDE.md
+- Periodically audit: "Is this still true? Is this still non-discoverable?"
+- Prefer fixing the code over documenting the gotcha
+- Start nearly empty, add only what causes agent confusion
+
+## Section Structure for Optimized CLAUDE.md
+
+Recommended sections (in order):
+
+1. **Project description** — 1-2 lines, what the project does + key constraint (e.g., "zero dependencies")
+2. **Development Commands** — Scripts and their purposes (not discoverable from code alone)
+3. **Design Rules** — Non-negotiable constraints that cause failures if violated
+4. **Gotchas & Landmines** — Categorized by domain (timing, config, platform, etc.)
+5. **Conventions** — Non-standard patterns specific to this project
+6. **Version/Release** — Workflow that can't be inferred from code
+7. **Testing** — Framework choice and priorities (especially if no tests exist yet)

--- a/.claude/skills/agents-md-optimizer/scripts/line-count.mjs
+++ b/.claude/skills/agents-md-optimizer/scripts/line-count.mjs
@@ -50,7 +50,8 @@ let tableLines = 0;
 for (let i = 0; i < lines.length; i++) {
   const line = lines[i];
 
-  // Track code blocks
+  // Track code blocks. Fence delimiter lines (```) are themselves counted
+  // in codeBlockLines, so the stat includes delimiters, not just content.
   if (line.trimStart().startsWith('```')) {
     inCodeBlock = !inCodeBlock;
     codeBlockLines++;
@@ -75,6 +76,8 @@ for (let i = 0; i < lines.length; i++) {
   const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
   if (headingMatch) {
     const level = headingMatch[1].length;
+    // Level-1 (# Title) is intentionally not tracked as a section — it's the
+    // document title. Matches the `grep -c '^##'` fallback in SKILL.md.
     if (level >= 2) {
       if (currentSection) {
         currentSection.endLine = i;

--- a/.claude/skills/agents-md-optimizer/scripts/line-count.mjs
+++ b/.claude/skills/agents-md-optimizer/scripts/line-count.mjs
@@ -34,7 +34,8 @@ try {
 
 // Split on \r?\n: CRLF checkouts (Windows core.autocrlf) leave a trailing \r
 // that breaks the heading regex below — `.` never matches \r, so `$` fails.
-const lines = content.split(/\r?\n/);
+// Strip the final newline first so totalLines matches `wc -l`.
+const lines = content.replace(/\r?\n$/, "").split(/\r?\n/);
 const totalLines = lines.length;
 const nonEmptyLines = lines.filter(l => l.trim().length > 0).length;
 
@@ -75,7 +76,8 @@ for (let i = 0; i < lines.length; i++) {
     if (level >= 2) {
       if (currentSection) {
         currentSection.endLine = i;
-        currentSection.lines = currentSection.endLine - currentSection.startLine;
+        // startLine..endLine is inclusive, so +1
+        currentSection.lines = currentSection.endLine - currentSection.startLine + 1;
         sections.push(currentSection);
       }
       currentSection = {
@@ -94,7 +96,8 @@ for (let i = 0; i < lines.length; i++) {
 // Close last section
 if (currentSection) {
   currentSection.endLine = totalLines;
-  currentSection.lines = currentSection.endLine - currentSection.startLine;
+  // startLine..endLine is inclusive, so +1
+  currentSection.lines = currentSection.endLine - currentSection.startLine + 1;
   sections.push(currentSection);
 }
 

--- a/.claude/skills/agents-md-optimizer/scripts/line-count.mjs
+++ b/.claude/skills/agents-md-optimizer/scripts/line-count.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+/**
+ * CLAUDE.md line count and section statistics
+ * Usage: node line-count.mjs <path-to-claude-md>
+ * Output: JSON with total lines, sections, code blocks, tables
+ * Exit codes: 0 = success, 1 = error
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const filePath = process.argv[2];
+
+if (!filePath) {
+  console.error(JSON.stringify({ error: 'No file path provided', usage: 'node line-count.mjs <path-to-file>' }));
+  process.exit(1);
+}
+
+const resolvedPath = resolve(filePath);
+
+if (!existsSync(resolvedPath)) {
+  console.error(JSON.stringify({ error: `File not found: ${resolvedPath}` }));
+  process.exit(1);
+}
+
+let content;
+try {
+  content = readFileSync(resolvedPath, 'utf8');
+} catch (err) {
+  console.error(JSON.stringify({ error: `Cannot read file: ${err.message}` }));
+  process.exit(1);
+}
+
+// Split on \r?\n: CRLF checkouts (Windows core.autocrlf) leave a trailing \r
+// that breaks the heading regex below — `.` never matches \r, so `$` fails.
+const lines = content.split(/\r?\n/);
+const totalLines = lines.length;
+const nonEmptyLines = lines.filter(l => l.trim().length > 0).length;
+
+const sections = [];
+let currentSection = null;
+let inCodeBlock = false;
+let codeBlockLines = 0;
+let tableLines = 0;
+
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+
+  // Track code blocks
+  if (line.trimStart().startsWith('```')) {
+    inCodeBlock = !inCodeBlock;
+    codeBlockLines++;
+    if (currentSection) currentSection.codeBlockLines++;
+    continue;
+  }
+
+  if (inCodeBlock) {
+    codeBlockLines++;
+    if (currentSection) currentSection.codeBlockLines++;
+    continue;
+  }
+
+  // Track tables
+  if (/^\s*\|.*\|/.test(line)) {
+    tableLines++;
+    if (currentSection) currentSection.tableLines++;
+    continue;
+  }
+
+  // Detect headings (## or ###)
+  const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+  if (headingMatch) {
+    const level = headingMatch[1].length;
+    if (level >= 2) {
+      if (currentSection) {
+        currentSection.endLine = i;
+        currentSection.lines = currentSection.endLine - currentSection.startLine;
+        sections.push(currentSection);
+      }
+      currentSection = {
+        heading: headingMatch[2].trim(),
+        level,
+        startLine: i + 1,
+        endLine: null,
+        lines: 0,
+        codeBlockLines: 0,
+        tableLines: 0
+      };
+    }
+  }
+}
+
+// Close last section
+if (currentSection) {
+  currentSection.endLine = totalLines;
+  currentSection.lines = currentSection.endLine - currentSection.startLine;
+  sections.push(currentSection);
+}
+
+const result = {
+  file: resolvedPath,
+  totalLines,
+  nonEmptyLines,
+  codeBlockLines,
+  tableLines,
+  sectionCount: sections.length,
+  sections
+};
+
+console.log(JSON.stringify(result, null, 2));

--- a/.claude/skills/agents-md-optimizer/scripts/line-count.mjs
+++ b/.claude/skills/agents-md-optimizer/scripts/line-count.mjs
@@ -39,6 +39,8 @@ const lines = content.replace(/\r?\n$/, "").split(/\r?\n/);
 const totalLines = lines.length;
 const nonEmptyLines = lines.filter(l => l.trim().length > 0).length;
 
+// Section bounds convention: startLine/endLine are 1-indexed and inclusive
+// (startLine = the heading line, endLine = the last line before the next heading or EOF).
 const sections = [];
 let currentSection = null;
 let inCodeBlock = false;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: "📝 Checking code format"
         run: pnpm run format:check
 
+      - name: "🔁 Check agent docs sync"
+        run: node scripts/check-agent-docs-sync.mjs
+
       - name: "🚀 Build the project"
         run: pnpm run build
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,13 +2,22 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    # synchronize(푸시마다 재리뷰)는 의도적으로 제외 — PR #78에서 푸시마다
+    # 전체 재리뷰가 돌며 8라운드 nit 루프(라운드 간 상호 모순 포함)를 만들었다.
+    # 자동 리뷰는 PR 오픈/드래프트 해제 시 1회. 이후 재리뷰가 필요하면
+    # PR 코멘트에서 @claude를 멘션한다 (claude.yml이 처리).
+    types: [opened, ready_for_review]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
     #   - "src/**/*.tsx"
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
+
+# 같은 PR에서 리뷰 실행이 겹치면 이전 실행을 취소하고 최신만 유지
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   claude-review:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,9 +54,9 @@ Page navigations swap the DOM without a full reload. Three rules prevent the lis
 ### CI & platform
 
 - The merge gate is the single `Code standards & build` job (audit → lint → format check → build → E2E). The `Claude Code Review` workflow is advisory — its failures do not block merges.
-- Windows: after `pnpm format`, `git status` may list files as modified with no real content change (CRLF). Judge with `git diff` and restore false positives with `git checkout`.
+- Windows: after `pnpm format`, `git status` may list files as modified with no real content change (CRLF). Judge with `git diff` and restore false positives with `git checkout`. A fresh Windows checkout can also fail `pnpm format:check` on nearly every file (`endOfLine: "lf"` vs CRLF working copies) — trust the CI verdict and never mass-reformat to "fix" it.
 - Playwright runs against the dev server (port 4321), not the build; CI uses 1 worker with 2 retries. Test fixtures reference real post slugs (`e2e/fixtures/test-posts.ts`) — renaming those posts breaks the suite.
-- `CLAUDE.md` and `AGENTS.md` are manual mirrors (tool-name/path substitutions only, no sync tooling) — when editing one, mirror the change to the other.
+- `CLAUDE.md` and `AGENTS.md` are mirrors — when editing one, mirror the change to the other. Only the title line, the intro line, and the `## Skills` section may differ; any other divergence fails CI (`node scripts/check-agent-docs-sync.mjs`).
 
 ## Skills (Codex 스킬 시스템)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ Page navigations swap the DOM without a full reload. Three rules prevent the lis
 
 ## Skills (Codex 스킬 시스템)
 
-`.agents/skills/`에 정의된 스킬들입니다. `/스킬이름`으로 호출합니다.
+`.agents/skills/`에 정의된 스킬들입니다. `/스킬이름`으로 호출합니다. Claude Code 전용 스킬(`/portfolio-strategy`, `/agents-md-optimizer`)은 `.claude/skills/`에만 존재합니다 — 아래 목록과 CLAUDE.md의 차이는 의도된 것입니다.
 
 - `/translate-writer` — 영어 → 한국어 번역 파이프라인 (에이전트 6개)
 - `/blog-writer` — 한국어 블로그 글 작성 (에이전트 4개)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Guide for Codex (Codex.ai/code) when working with code in this repository.
+Guide for Codex (OpenAI Codex) when working with code in this repository.
 
 ## Project Overview
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,206 +4,68 @@ Guide for Codex (Codex.ai/code) when working with code in this repository.
 
 ## Project Overview
 
-Caesiumy's personal blog website built with Astro and AstroPaper template. This is the production-ready blog at https://caesiumy.github.io/
-
-## Project Information
-
-### AstroPaper Template
-- **Template**: [AstroPaper v5.5.0](https://github.com/satnaing/astro-paper)
-- **Framework**: Astro v5.12.0 (SSG)
-- **Styling**: TailwindCSS v4.1.11
-- **Type Checking**: TypeScript v5.8.3
-- **Search**: Pagefind (static search)
-
-### Core Features
-- ✅ Responsive design (mobile ~ desktop)
-- ✅ Accessibility support (VoiceOver, TalkBack tested)
-- ✅ SEO optimized
-- ✅ Light & dark mode
-- ✅ Fuzzy search functionality
-- ✅ Draft posts & pagination
-- ✅ Sitemap & RSS feed
-- ✅ Dynamic OG image generation
+Caesiumy's personal blog at https://caesiumy.dev — Astro SSG, started from the AstroPaper template and customized since. Blog posts live in `contents/blog/` (not `src/content/`).
 
 ## Development Commands
 
 ```bash
-pnpm install       # Install dependencies
-pnpm dev          # Dev server (localhost:4321)
-pnpm build        # Production build
-pnpm preview      # Build preview
-pnpm format       # Code formatting (Prettier)
-pnpm lint         # ESLint linting
-pnpm sync         # Astro type sync
+pnpm install       # Install dependencies (pnpm 10, Node >= 22)
+pnpm dev           # Dev server (localhost:4321)
+pnpm build         # astro check + astro build + pagefind index + copy to public/
+pnpm preview       # Preview the production build
+pnpm test          # Playwright E2E tests (auto-starts the dev server)
+pnpm lint          # ESLint
+pnpm format        # Prettier write (see Windows gotcha below)
+pnpm sync          # Astro type sync
 ```
 
-## Project Structure
+## Design Rules
 
-```
-CaesiumY.github.io/
-├── contents/            # Content files
-│   └── blog/           # Blog posts (Markdown)
-├── src/
-│   ├── components/     # Reusable components
-│   ├── layouts/        # Page layouts
-│   ├── pages/          # File-based routing
-│   ├── styles/         # Global CSS
-│   ├── utils/          # Utility functions
-│   ├── config.ts       # Site configuration
-│   └── content.config.ts # Content schema definitions
-├── public/             # Static assets
-├── dist/               # Build output
-├── node_modules/       # Dependencies
-├── package.json        # Project dependencies
-├── tsconfig.json       # TypeScript configuration
-├── astro.config.ts     # Astro configuration
-├── AGENTS.md          # This file
-└── README.md          # Project documentation
-```
+- ⚠️ IMPORTANT: Blog post images live in the same folder as the post markdown (`contents/blog/<post>/image.png`, referenced as `./image.png`) — never in `public/`, which bypasses Astro image optimization. Use markdown image syntax, not HTML `<img>` tags.
+- ⚠️ IMPORTANT: Never disable ESLint rules or ignore files without explicit user permission — fix the root cause instead. If disabling is truly unavoidable, write `// eslint-disable-next-line <rule> -- Reason: <detailed reason>` and report it as a "Confirmation Required" item in your final response.
+- Verify changes with `pnpm build` and inspect `dist/`, not just the dev server — image optimization, pagefind indexing, and scheduled-post filtering happen only at build time, so dev-only verification can pass while the build is broken.
+- Use Conventional Commits for all commit messages.
 
-## Content Management
+## Gotchas & Landmines
 
-### Blog Posts
-- **Location**: `contents/blog/`
-- **Format**: Markdown/MDX
-- **Frontmatter Schema**:
-```yaml
-title: "Post title"
-description: "Post description"
-pubDate: 2025-01-01
-updatedDate: 2025-01-02  # Optional
-heroImage: "/hero.jpg"    # Optional
-draft: false             # Default: false
-tags: ["tag1", "tag2"]   # Optional
-```
+### View Transitions (ClientRouter)
 
-### Blog Images
-- **⚠️ IMPORTANT**: Blog post images must be located in the same directory as the blog post markdown file
-- **Structure**: `contents/blog/[post-folder]/[image-file]`
-- **Example**:
-  ```
-  contents/blog/
-  └── my-blog-post/
-      ├── index.md        # Blog post content
-      ├── hero-image.png  # Post images
-      └── diagram.jpg     # Additional images
-  ```
-- **Usage in Markdown**: Use relative paths `![alt text](./image.png)`
-- **❌ DO NOT**: Place blog images in `public/` folder - this bypasses Astro's image optimization
-- **✅ Benefits**: Automatic WebP conversion, srcset generation, compression, and caching
+Page navigations swap the DOM without a full reload. Three rules prevent the listener-leak class of bugs (fixed across PR #75/#76, guarded by `e2e/listener-leak.spec.ts`):
 
-### Static Assets
-- **Images**: `public/assets/` or `src/assets/images/` (for site-wide assets only)
-- **Icons**: `src/assets/icons/`
-- **Favicon**: `public/favicon.svg`
+- An inline `<script>` without `data-astro-rerun` runs once per browser session — listeners attached directly to page elements go dead on revisit. Attach to `document` with event delegation plus a global guard flag instead (pattern: `ThemeToggle.astro`, `PdfDownloadButton.astro`).
+- Never add listeners to persistent targets (`document`, `window`, `MediaQueryList`) on every swap — they accumulate. Sanctioned patterns: `data-astro-rerun` + AbortController aborted on `astro:before-swap` (`BackToTopButton.astro`, `progressBar.ts`), or hoist the listener to module top level and query the DOM fresh inside the handler (`Navigation.astro`).
+- Never cache DOM element references in module scope — after a swap they point at a detached tree (this silently broke ShareLinks). Re-initialize on `astro:page-load` with an idempotency guard (`ShareLinks.astro`).
+- When adding a new interactive script, extend `e2e/listener-leak.spec.ts` so the leak invariant covers it.
+
+### Content pipeline
+
+- Markdown files starting with `_` are excluded from the blog collection entirely (loader pattern `**/[^_]*.md`) — a stronger exclusion than `draft: true`.
+- Scheduled publishing is build-time only: a post with a future `pubDatetime` stays hidden until a build runs after that time (minus the 15-minute `SITE.scheduledPostMargin`). Without a redeploy it never appears. Dev mode shows drafts.
+- Omitted `tags` defaults to `["others"]`.
+- A `## 목차` heading inside a post triggers remark-toc auto-generation, collapsed under "목차 보기".
+- The frontmatter schema lives in `src/content.config.ts` (`pubDatetime`, `modDatetime`, `ogImage`, `series`, ...) — read it before writing frontmatter; field names differ from upstream AstroPaper docs.
+
+### Build & search
+
+- The build chain is `astro check && astro build && pagefind --site dist && cp -r dist/pagefind public/`. The copied `public/pagefind` is gitignored — search in dev mode only works after at least one local build.
+- Dynamic OG images (satori) require three local font files in `src/assets/fonts/` (Pretendard Regular/Bold, NotoEmoji) — missing fonts throw and fail the build.
+
+### CI & platform
+
+- The merge gate is the single `Code standards & build` job (audit → lint → format check → build → E2E). The `Claude Code Review` workflow is advisory — its failures do not block merges.
+- Windows: after `pnpm format`, `git status` may list files as modified with no real content change (CRLF). Judge with `git diff` and restore false positives with `git checkout`.
+- Playwright runs against the dev server (port 4321), not the build; CI uses 1 worker with 2 retries. Test fixtures reference real post slugs (`e2e/fixtures/test-posts.ts`) — renaming those posts breaks the suite.
 
 ## Skills (Codex 스킬 시스템)
 
-`.agents/skills/` 디렉토리에 정의된 스킬들입니다. `/스킬이름`으로 호출합니다.
+`.agents/skills/`에 정의된 스킬들입니다. `/스킬이름`으로 호출합니다.
 
-| 스킬 | 용도 | 에이전트 수 |
-|------|------|------------|
-| `/translate-writer` | 영어 → 한국어 번역 파이프라인 | 6개 |
-| `/polish` | 개별 문장 다듬기 (점수 + 옵션 제시) | 1개 |
-| `/polish-file` | 파일 전체 문장 품질 분석 + 순차 개선 | 1개 |
-| `/blog-writer` | 한국어 블로그 글 작성 | 4개 |
-| `/resume-specialist` | 이력서 작성/검토/ATS 최적화 | 1개 |
+- `/translate-writer` — 영어 → 한국어 번역 파이프라인 (에이전트 6개)
+- `/blog-writer` — 한국어 블로그 글 작성 (에이전트 4개)
+- `/polish`, `/polish-file` — 개별 문장 / 파일 전체 다듬기
+- `/resume-specialist` — 이력서 작성·검토·ATS 최적화
+- 역할 프롬프트 정의: `.agents/agents/` · 번역 스타일 가이드/용어집: `.agents/skills/translate-writer/data/`
 
-- 역할 프롬프트 정의: `.agents/agents/`
-- 번역투 28개 패턴: `.agents/skills/translate-writer/references/translation-patterns.md`
-- 스타일 가이드/용어집: `.agents/skills/translate-writer/data/`
+## Environment
 
-## Styling Guidelines
-
-### TailwindCSS
-- Uses TailwindCSS v4
-- Typography plugin enabled
-- Dark mode support (`dark:` prefix)
-
-### Component Development
-- Prefer Astro components (.astro)
-- TypeScript support
-- Accessibility considerations (ARIA, semantic HTML)
-
-## SEO & Performance
-
-### SEO Optimization
-- Automatic sitemap generation
-- RSS feed support
-- Dynamic OG image generation
-- Meta tag optimization
-
-### Performance Optimization
-- Astro Island Architecture
-- Image optimization (Sharp)
-- Code splitting
-- Lighthouse score: 100 target
-
-## Deployment
-
-### Build Process
-1. `astro check` - Type checking
-2. `astro build` - Production build
-3. `pagefind` - Search index generation
-4. Static files generation (`dist/`)
-
-### Environment Variables (Optional)
-```bash
-PUBLIC_GOOGLE_SITE_VERIFICATION=your-google-site-verification-value
-```
-
-## Development Guidelines
-
-### Code Quality
-- ESLint + Prettier usage
-- TypeScript strict mode
-- Conventional Commits compliance
-- **⚠️ IMPORTANT**: Do NOT disable ESLint rules or ignore files without explicit user permission
-- If ESLint errors occur, investigate and fix the root cause rather than bypassing the linter
-- **If ESLint disabling is absolutely necessary:**
-  - Add a detailed comment explaining the reason for disabling
-  - Include the issue in the final response as a "Confirmation Required" item
-  - Example: `// eslint-disable-next-line rule-name -- Reason: [detailed explanation]`
-
-### Work Verification Guidelines
-- **⚠️ IMPORTANT**: Always verify work by building and checking the `dist/` folder, not just the development server
-- **Build Verification Process**:
-  1. Run `pnpm build` to create production build
-  2. Check the generated files in `dist/` folder
-  3. Verify that all changes are properly reflected in the static output
-  4. Test critical paths and functionality in the built version
-- **Why Build Verification is Critical**:
-  - Development server may not reflect all build-time optimizations
-  - Static site generation (SSG) behavior differs from development mode
-  - Image optimization, bundle splitting, and other build processes only occur during build
-  - Some Astro features and optimizations are build-time only
-
-### Component Development
-- Write reusable components
-- Define Props types
-- Follow accessibility guidelines
-
-### Content Writing
-- SEO-friendly titles and descriptions
-- Proper tag categorization
-- Provide image alt text
-- Use markdown image syntax (not HTML `<img>` tags) for Astro optimization
-- Place images in same directory as markdown files for proper processing
-
-## Key Features
-
-### Accessibility
-- Keyboard navigation support
-- Screen reader compatibility
-- Sufficient color contrast
-- ARIA labels provided
-
-### Search Functionality
-- Static search via Pagefind
-- Fuzzy search support
-- Real-time search results
-
-### Dark Mode
-- System preference detection
-- Toggle button provided
-- Settings stored in localStorage
+Optional env vars (schema in `astro.config.ts`): `PUBLIC_GOOGLE_SITE_VERIFICATION`, `PUBLIC_GOOGLE_ANALYTICS_ID`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ Page navigations swap the DOM without a full reload. Three rules prevent the lis
 - The merge gate is the single `Code standards & build` job (audit → lint → format check → build → E2E). The `Claude Code Review` workflow is advisory — its failures do not block merges.
 - Windows: after `pnpm format`, `git status` may list files as modified with no real content change (CRLF). Judge with `git diff` and restore false positives with `git checkout`.
 - Playwright runs against the dev server (port 4321), not the build; CI uses 1 worker with 2 retries. Test fixtures reference real post slugs (`e2e/fixtures/test-posts.ts`) — renaming those posts breaks the suite.
+- `CLAUDE.md` and `AGENTS.md` are manual mirrors (tool-name/path substitutions only, no sync tooling) — when editing one, mirror the change to the other.
 
 ## Skills (Codex 스킬 시스템)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ pnpm build         # astro check + astro build + pagefind index + copy to public
 pnpm preview       # Preview the production build
 pnpm test          # Playwright E2E tests (auto-starts the dev server)
 pnpm lint          # ESLint
-pnpm format        # Prettier write (see Windows gotcha below)
+pnpm format        # Prettier write (see the CI & platform gotchas)
 pnpm sync          # Astro type sync
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Page navigations swap the DOM without a full reload. Three rules prevent the lis
 - The merge gate is the single `Code standards & build` job (audit → lint → format check → build → E2E). The `Claude Code Review` workflow is advisory — its failures do not block merges.
 - Windows: after `pnpm format`, `git status` may list files as modified with no real content change (CRLF). Judge with `git diff` and restore false positives with `git checkout`.
 - Playwright runs against the dev server (port 4321), not the build; CI uses 1 worker with 2 retries. Test fixtures reference real post slugs (`e2e/fixtures/test-posts.ts`) — renaming those posts breaks the suite.
+- `CLAUDE.md` and `AGENTS.md` are manual mirrors (tool-name/path substitutions only, no sync tooling) — when editing one, mirror the change to the other.
 
 ## Skills (Claude Code 스킬 시스템)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,9 @@ Page navigations swap the DOM without a full reload. Three rules prevent the lis
 ### CI & platform
 
 - The merge gate is the single `Code standards & build` job (audit → lint → format check → build → E2E). The `Claude Code Review` workflow is advisory — its failures do not block merges.
-- Windows: after `pnpm format`, `git status` may list files as modified with no real content change (CRLF). Judge with `git diff` and restore false positives with `git checkout`.
+- Windows: after `pnpm format`, `git status` may list files as modified with no real content change (CRLF). Judge with `git diff` and restore false positives with `git checkout`. A fresh Windows checkout can also fail `pnpm format:check` on nearly every file (`endOfLine: "lf"` vs CRLF working copies) — trust the CI verdict and never mass-reformat to "fix" it.
 - Playwright runs against the dev server (port 4321), not the build; CI uses 1 worker with 2 retries. Test fixtures reference real post slugs (`e2e/fixtures/test-posts.ts`) — renaming those posts breaks the suite.
-- `CLAUDE.md` and `AGENTS.md` are manual mirrors (tool-name/path substitutions only, no sync tooling) — when editing one, mirror the change to the other.
+- `CLAUDE.md` and `AGENTS.md` are mirrors — when editing one, mirror the change to the other. Only the title line, the intro line, and the `## Skills` section may differ; any other divergence fails CI (`node scripts/check-agent-docs-sync.mjs`).
 
 ## Skills (Claude Code 스킬 시스템)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,206 +4,70 @@ Guide for Claude Code (claude.ai/code) when working with code in this repository
 
 ## Project Overview
 
-Caesiumy's personal blog website built with Astro and AstroPaper template. This is the production-ready blog at https://caesiumy.github.io/
-
-## Project Information
-
-### AstroPaper Template
-- **Template**: [AstroPaper v5.5.0](https://github.com/satnaing/astro-paper)
-- **Framework**: Astro v5.12.0 (SSG)
-- **Styling**: TailwindCSS v4.1.11
-- **Type Checking**: TypeScript v5.8.3
-- **Search**: Pagefind (static search)
-
-### Core Features
-- ✅ Responsive design (mobile ~ desktop)
-- ✅ Accessibility support (VoiceOver, TalkBack tested)
-- ✅ SEO optimized
-- ✅ Light & dark mode
-- ✅ Fuzzy search functionality
-- ✅ Draft posts & pagination
-- ✅ Sitemap & RSS feed
-- ✅ Dynamic OG image generation
+Caesiumy's personal blog at https://caesiumy.dev — Astro SSG, started from the AstroPaper template and customized since. Blog posts live in `contents/blog/` (not `src/content/`).
 
 ## Development Commands
 
 ```bash
-pnpm install       # Install dependencies
-pnpm dev          # Dev server (localhost:4321)
-pnpm build        # Production build
-pnpm preview      # Build preview
-pnpm format       # Code formatting (Prettier)
-pnpm lint         # ESLint linting
-pnpm sync         # Astro type sync
+pnpm install       # Install dependencies (pnpm 10, Node >= 22)
+pnpm dev           # Dev server (localhost:4321)
+pnpm build         # astro check + astro build + pagefind index + copy to public/
+pnpm preview       # Preview the production build
+pnpm test          # Playwright E2E tests (auto-starts the dev server)
+pnpm lint          # ESLint
+pnpm format        # Prettier write (see Windows gotcha below)
+pnpm sync          # Astro type sync
 ```
 
-## Project Structure
+## Design Rules
 
-```
-CaesiumY.github.io/
-├── contents/            # Content files
-│   └── blog/           # Blog posts (Markdown)
-├── src/
-│   ├── components/     # Reusable components
-│   ├── layouts/        # Page layouts
-│   ├── pages/          # File-based routing
-│   ├── styles/         # Global CSS
-│   ├── utils/          # Utility functions
-│   ├── config.ts       # Site configuration
-│   └── content.config.ts # Content schema definitions
-├── public/             # Static assets
-├── dist/               # Build output
-├── node_modules/       # Dependencies
-├── package.json        # Project dependencies
-├── tsconfig.json       # TypeScript configuration
-├── astro.config.ts     # Astro configuration
-├── CLAUDE.md          # This file
-└── README.md          # Project documentation
-```
+- ⚠️ IMPORTANT: Blog post images live in the same folder as the post markdown (`contents/blog/<post>/image.png`, referenced as `./image.png`) — never in `public/`, which bypasses Astro image optimization. Use markdown image syntax, not HTML `<img>` tags.
+- ⚠️ IMPORTANT: Never disable ESLint rules or ignore files without explicit user permission — fix the root cause instead. If disabling is truly unavoidable, write `// eslint-disable-next-line <rule> -- Reason: <detailed reason>` and report it as a "Confirmation Required" item in your final response.
+- Verify changes with `pnpm build` and inspect `dist/`, not just the dev server — image optimization, pagefind indexing, and scheduled-post filtering happen only at build time, so dev-only verification can pass while the build is broken.
+- Use Conventional Commits for all commit messages.
 
-## Content Management
+## Gotchas & Landmines
 
-### Blog Posts
-- **Location**: `contents/blog/`
-- **Format**: Markdown/MDX
-- **Frontmatter Schema**:
-```yaml
-title: "Post title"
-description: "Post description"
-pubDate: 2025-01-01
-updatedDate: 2025-01-02  # Optional
-heroImage: "/hero.jpg"    # Optional
-draft: false             # Default: false
-tags: ["tag1", "tag2"]   # Optional
-```
+### View Transitions (ClientRouter)
 
-### Blog Images
-- **⚠️ IMPORTANT**: Blog post images must be located in the same directory as the blog post markdown file
-- **Structure**: `contents/blog/[post-folder]/[image-file]`
-- **Example**:
-  ```
-  contents/blog/
-  └── my-blog-post/
-      ├── index.md        # Blog post content
-      ├── hero-image.png  # Post images
-      └── diagram.jpg     # Additional images
-  ```
-- **Usage in Markdown**: Use relative paths `![alt text](./image.png)`
-- **❌ DO NOT**: Place blog images in `public/` folder - this bypasses Astro's image optimization
-- **✅ Benefits**: Automatic WebP conversion, srcset generation, compression, and caching
+Page navigations swap the DOM without a full reload. Three rules prevent the listener-leak class of bugs (fixed across PR #75/#76, guarded by `e2e/listener-leak.spec.ts`):
 
-### Static Assets
-- **Images**: `public/assets/` or `src/assets/images/` (for site-wide assets only)
-- **Icons**: `src/assets/icons/`
-- **Favicon**: `public/favicon.svg`
+- An inline `<script>` without `data-astro-rerun` runs once per browser session — listeners attached directly to page elements go dead on revisit. Attach to `document` with event delegation plus a global guard flag instead (pattern: `ThemeToggle.astro`, `PdfDownloadButton.astro`).
+- Never add listeners to persistent targets (`document`, `window`, `MediaQueryList`) on every swap — they accumulate. Sanctioned patterns: `data-astro-rerun` + AbortController aborted on `astro:before-swap` (`BackToTopButton.astro`, `progressBar.ts`), or hoist the listener to module top level and query the DOM fresh inside the handler (`Navigation.astro`).
+- Never cache DOM element references in module scope — after a swap they point at a detached tree (this silently broke ShareLinks). Re-initialize on `astro:page-load` with an idempotency guard (`ShareLinks.astro`).
+- When adding a new interactive script, extend `e2e/listener-leak.spec.ts` so the leak invariant covers it.
+
+### Content pipeline
+
+- Markdown files starting with `_` are excluded from the blog collection entirely (loader pattern `**/[^_]*.md`) — a stronger exclusion than `draft: true`.
+- Scheduled publishing is build-time only: a post with a future `pubDatetime` stays hidden until a build runs after that time (minus the 15-minute `SITE.scheduledPostMargin`). Without a redeploy it never appears. Dev mode shows drafts.
+- Omitted `tags` defaults to `["others"]`.
+- A `## 목차` heading inside a post triggers remark-toc auto-generation, collapsed under "목차 보기".
+- The frontmatter schema lives in `src/content.config.ts` (`pubDatetime`, `modDatetime`, `ogImage`, `series`, ...) — read it before writing frontmatter; field names differ from upstream AstroPaper docs.
+
+### Build & search
+
+- The build chain is `astro check && astro build && pagefind --site dist && cp -r dist/pagefind public/`. The copied `public/pagefind` is gitignored — search in dev mode only works after at least one local build.
+- Dynamic OG images (satori) require three local font files in `src/assets/fonts/` (Pretendard Regular/Bold, NotoEmoji) — missing fonts throw and fail the build.
+
+### CI & platform
+
+- The merge gate is the single `Code standards & build` job (audit → lint → format check → build → E2E). The `Claude Code Review` workflow is advisory — its failures do not block merges.
+- Windows: after `pnpm format`, `git status` may list files as modified with no real content change (CRLF). Judge with `git diff` and restore false positives with `git checkout`.
+- Playwright runs against the dev server (port 4321), not the build; CI uses 1 worker with 2 retries. Test fixtures reference real post slugs (`e2e/fixtures/test-posts.ts`) — renaming those posts breaks the suite.
 
 ## Skills (Claude Code 스킬 시스템)
 
-`.claude/skills/` 디렉토리에 정의된 스킬들입니다. `/스킬이름`으로 호출합니다.
+`.claude/skills/`에 정의된 스킬들입니다. `/스킬이름`으로 호출합니다.
 
-| 스킬 | 용도 | 에이전트 수 |
-|------|------|------------|
-| `/translate-writer` | 영어 → 한국어 번역 파이프라인 | 6개 |
-| `/polish` | 개별 문장 다듬기 (점수 + 옵션 제시) | 1개 |
-| `/polish-file` | 파일 전체 문장 품질 분석 + 순차 개선 | 1개 |
-| `/blog-writer` | 한국어 블로그 글 작성 | 4개 |
-| `/resume-specialist` | 이력서 작성/검토/ATS 최적화 | 1개 |
+- `/translate-writer` — 영어 → 한국어 번역 파이프라인 (에이전트 6개)
+- `/blog-writer` — 한국어 블로그 글 작성 (에이전트 4개)
+- `/polish`, `/polish-file` — 개별 문장 / 파일 전체 다듬기
+- `/resume-specialist` — 이력서 작성·검토·ATS 최적화
+- `/portfolio-strategy` — 인터뷰형 포트폴리오 섹션 작성
+- `/agents-md-optimizer` — CLAUDE.md/AGENTS.md discoverability 최적화
+- 에이전트 정의: `.claude/agents/` · 번역 스타일 가이드/용어집: `.claude/skills/translate-writer/data/`
 
-- 에이전트 정의: `.claude/agents/`
-- 번역투 28개 패턴: `.claude/skills/translate-writer/references/translation-patterns.md`
-- 스타일 가이드/용어집: `.claude/skills/translate-writer/data/`
+## Environment
 
-## Styling Guidelines
-
-### TailwindCSS
-- Uses TailwindCSS v4
-- Typography plugin enabled
-- Dark mode support (`dark:` prefix)
-
-### Component Development
-- Prefer Astro components (.astro)
-- TypeScript support
-- Accessibility considerations (ARIA, semantic HTML)
-
-## SEO & Performance
-
-### SEO Optimization
-- Automatic sitemap generation
-- RSS feed support
-- Dynamic OG image generation
-- Meta tag optimization
-
-### Performance Optimization
-- Astro Island Architecture
-- Image optimization (Sharp)
-- Code splitting
-- Lighthouse score: 100 target
-
-## Deployment
-
-### Build Process
-1. `astro check` - Type checking
-2. `astro build` - Production build
-3. `pagefind` - Search index generation
-4. Static files generation (`dist/`)
-
-### Environment Variables (Optional)
-```bash
-PUBLIC_GOOGLE_SITE_VERIFICATION=your-google-site-verification-value
-```
-
-## Development Guidelines
-
-### Code Quality
-- ESLint + Prettier usage
-- TypeScript strict mode
-- Conventional Commits compliance
-- **⚠️ IMPORTANT**: Do NOT disable ESLint rules or ignore files without explicit user permission
-- If ESLint errors occur, investigate and fix the root cause rather than bypassing the linter
-- **If ESLint disabling is absolutely necessary:**
-  - Add a detailed comment explaining the reason for disabling
-  - Include the issue in the final response as a "Confirmation Required" item
-  - Example: `// eslint-disable-next-line rule-name -- Reason: [detailed explanation]`
-
-### Work Verification Guidelines
-- **⚠️ IMPORTANT**: Always verify work by building and checking the `dist/` folder, not just the development server
-- **Build Verification Process**:
-  1. Run `pnpm build` to create production build
-  2. Check the generated files in `dist/` folder
-  3. Verify that all changes are properly reflected in the static output
-  4. Test critical paths and functionality in the built version
-- **Why Build Verification is Critical**:
-  - Development server may not reflect all build-time optimizations
-  - Static site generation (SSG) behavior differs from development mode
-  - Image optimization, bundle splitting, and other build processes only occur during build
-  - Some Astro features and optimizations are build-time only
-
-### Component Development
-- Write reusable components
-- Define Props types
-- Follow accessibility guidelines
-
-### Content Writing
-- SEO-friendly titles and descriptions
-- Proper tag categorization
-- Provide image alt text
-- Use markdown image syntax (not HTML `<img>` tags) for Astro optimization
-- Place images in same directory as markdown files for proper processing
-
-## Key Features
-
-### Accessibility
-- Keyboard navigation support
-- Screen reader compatibility
-- Sufficient color contrast
-- ARIA labels provided
-
-### Search Functionality
-- Static search via Pagefind
-- Fuzzy search support
-- Real-time search results
-
-### Dark Mode
-- System preference detection
-- Toggle button provided
-- Settings stored in localStorage
+Optional env vars (schema in `astro.config.ts`): `PUBLIC_GOOGLE_SITE_VERIFICATION`, `PUBLIC_GOOGLE_ANALYTICS_ID`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ pnpm build         # astro check + astro build + pagefind index + copy to public
 pnpm preview       # Preview the production build
 pnpm test          # Playwright E2E tests (auto-starts the dev server)
 pnpm lint          # ESLint
-pnpm format        # Prettier write (see Windows gotcha below)
+pnpm format        # Prettier write (see the CI & platform gotchas)
 pnpm sync          # Astro type sync
 ```
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,5 +14,10 @@ export default [
     },
   },
   { rules: { "no-console": "error" } },
+  {
+    // 스킬 CLI 스크립트는 console(stdout/stderr) 출력이 인터페이스 그 자체 — 이 디렉터리만 no-console 해제 (사용자 승인)
+    files: [".claude/skills/**/scripts/**"],
+    rules: { "no-console": "off" },
+  },
   { ignores: ["dist/**", ".astro", "public/pagefind/**"] },
 ];

--- a/scripts/check-agent-docs-sync.mjs
+++ b/scripts/check-agent-docs-sync.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+/**
+ * CLAUDE.md ↔ AGENTS.md mirror sync check.
+ *
+ * The two files are manual mirrors. Only these differences are allowed:
+ *   1. Title line:  "# CLAUDE.md" vs "# AGENTS.md"
+ *   2. Intro line:  the "Guide for ..." sentence (tool name differs)
+ *   3. The Skills section: heading suffix and body are tool-specific by
+ *      design (skill lists and .claude/ vs .agents/ paths differ)
+ * Everything else must match line for line.
+ *
+ * If you intentionally reword the title/intro/Skills heading, update the
+ * pinned constants below — the check pins exact strings on purpose so that
+ * accidental edits to one file cannot pass as "allowed" differences.
+ *
+ * Usage: node scripts/check-agent-docs-sync.mjs [claude-md agents-md]
+ * Exit codes: 0 = in sync, 1 = drift or structural mismatch.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+// Resolve against the repo root (script location), not cwd — the check must
+// behave identically no matter where it is invoked from.
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+const claudePath = process.argv[2] ?? path.join(repoRoot, "CLAUDE.md");
+const agentsPath = process.argv[3] ?? path.join(repoRoot, "AGENTS.md");
+
+const TITLE_PAIR = ["# CLAUDE.md", "# AGENTS.md"];
+const INTRO_PAIR = [
+  "Guide for Claude Code (claude.ai/code) when working with code in this repository.",
+  "Guide for Codex (OpenAI Codex) when working with code in this repository.",
+];
+const SKILLS_HEADING_PAIR = [
+  "## Skills (Claude Code 스킬 시스템)",
+  "## Skills (Codex 스킬 시스템)",
+];
+
+const problems = [];
+
+function readSections(filePath) {
+  // CRLF-safe split; drop the final newline so the last element is a real line.
+  const lines = readFileSync(filePath, "utf8")
+    .replace(/\r?\n$/, "")
+    .split(/\r?\n/);
+  const sections = [{ heading: "(preamble)", lines: [] }];
+  for (const line of lines) {
+    if (line.startsWith("## ")) {
+      sections.push({ heading: line, lines: [] });
+    } else {
+      sections.at(-1).lines.push(line);
+    }
+  }
+  return sections;
+}
+
+function compareLines(label, expected, actual) {
+  const max = Math.max(expected.length, actual.length);
+  for (let i = 0; i < max; i++) {
+    if (expected[i] !== actual[i]) {
+      problems.push(
+        `${label} — line ${i + 1} of the section differs:\n` +
+          `  CLAUDE.md (expected mirror): ${expected[i] ?? "<missing>"}\n` +
+          `  AGENTS.md (actual)         : ${actual[i] ?? "<missing>"}`
+      );
+      return; // first divergence per section is enough to act on
+    }
+  }
+}
+
+let claude, agents;
+try {
+  claude = readSections(claudePath);
+  agents = readSections(agentsPath);
+} catch (err) {
+  process.stderr.write(`agent-docs-sync: cannot read input: ${err.message}\n`);
+  process.exit(1);
+}
+
+// 1) Preamble: title and intro lines map pairwise, the rest must be identical.
+const expectedPreamble = claude[0].lines.map(line => {
+  if (line === TITLE_PAIR[0]) return TITLE_PAIR[1];
+  if (line === INTRO_PAIR[0]) return INTRO_PAIR[1];
+  return line;
+});
+compareLines("(preamble)", expectedPreamble, agents[0].lines);
+if (!claude[0].lines.includes(TITLE_PAIR[0])) {
+  problems.push(
+    `CLAUDE.md title line "${TITLE_PAIR[0]}" not found — update TITLE_PAIR if it was renamed intentionally.`
+  );
+}
+if (!claude[0].lines.includes(INTRO_PAIR[0])) {
+  problems.push(
+    `CLAUDE.md intro line not found — update INTRO_PAIR if it was reworded intentionally.`
+  );
+}
+
+// 2) Sections: same count and order; Skills heading maps pairwise and its
+//    body is exempt; every other section must be identical.
+if (claude.length !== agents.length) {
+  problems.push(
+    `Section count differs: CLAUDE.md has ${claude.length - 1} "## " sections, AGENTS.md has ${agents.length - 1}.`
+  );
+} else {
+  for (let i = 1; i < claude.length; i++) {
+    const c = claude[i];
+    const a = agents[i];
+    if (c.heading === SKILLS_HEADING_PAIR[0]) {
+      if (a.heading !== SKILLS_HEADING_PAIR[1]) {
+        problems.push(
+          `Skills heading mismatch: expected "${SKILLS_HEADING_PAIR[1]}", found "${a.heading}".`
+        );
+      }
+      continue; // Skills body is tool-specific by design
+    }
+    if (c.heading !== a.heading) {
+      problems.push(
+        `Section order/heading mismatch at position ${i}: "${c.heading}" vs "${a.heading}".`
+      );
+      continue;
+    }
+    compareLines(c.heading, c.lines, a.lines);
+  }
+}
+
+if (problems.length > 0) {
+  process.stderr.write(
+    `agent-docs-sync: CLAUDE.md and AGENTS.md have drifted (${problems.length} problem(s)).\n` +
+      `Allowed differences are only the title line, the intro line, and the Skills section.\n\n` +
+      problems.map(p => `* ${p}`).join("\n\n") +
+      `\n\nFix: mirror the edit to both files (see the "manual mirrors" note in CLAUDE.md).\n`
+  );
+  process.exit(1);
+}
+
+process.stdout.write("agent-docs-sync: CLAUDE.md and AGENTS.md are in sync.\n");

--- a/scripts/check-agent-docs-sync.mjs
+++ b/scripts/check-agent-docs-sync.mjs
@@ -144,7 +144,9 @@ if (problems.length > 0) {
     `agent-docs-sync: CLAUDE.md and AGENTS.md have drifted (${problems.length} problem(s)).\n` +
       `Allowed differences are only the title line, the intro line, and the Skills section.\n\n` +
       problems.map(p => `* ${p}`).join("\n\n") +
-      `\n\nFix: mirror the edit to both files (see the "manual mirrors" note in CLAUDE.md).\n`
+      `\n\nFix: mirror the edit to both files (see the "manual mirrors" note in CLAUDE.md).\n` +
+      `Tip: reports are positional — a single inserted/removed line cascades through the rest\n` +
+      `of its section, so diff the first named section directly to find the root edit.\n`
   );
   process.exit(1);
 }

--- a/scripts/check-agent-docs-sync.mjs
+++ b/scripts/check-agent-docs-sync.mjs
@@ -60,16 +60,24 @@ function readSections(filePath) {
 }
 
 function compareLines(label, expected, actual) {
+  // Positional comparison (no LCS): one inserted line marks the rest of the
+  // section as differing. The cap below keeps such reports readable.
   const max = Math.max(expected.length, actual.length);
+  const mismatches = [];
   for (let i = 0; i < max; i++) {
-    if (expected[i] !== actual[i]) {
-      problems.push(
-        `${label} — line ${i + 1} of the section differs:\n` +
-          `  CLAUDE.md (expected mirror): ${expected[i] ?? "<missing>"}\n` +
-          `  AGENTS.md (actual)         : ${actual[i] ?? "<missing>"}`
-      );
-      return; // first divergence per section is enough to act on
-    }
+    if (expected[i] !== actual[i]) mismatches.push(i);
+  }
+  for (const i of mismatches.slice(0, 3)) {
+    problems.push(
+      `${label} — line ${i + 1} of the section differs:\n` +
+        `  CLAUDE.md (expected mirror): ${expected[i] ?? "<missing>"}\n` +
+        `  AGENTS.md (actual)         : ${actual[i] ?? "<missing>"}`
+    );
+  }
+  if (mismatches.length > 3) {
+    problems.push(
+      `${label} — ${mismatches.length - 3} more differing line(s) in this section (showing first 3).`
+    );
   }
 }
 
@@ -116,7 +124,10 @@ if (claude.length !== agents.length) {
           `Skills heading mismatch: expected "${SKILLS_HEADING_PAIR[1]}", found "${a.heading}".`
         );
       }
-      continue; // Skills body is tool-specific by design
+      // Skills body is tool-specific by design: the skill list, the intro
+      // sentence, and .claude/ vs .agents/ paths may all differ here. Keep
+      // the exemption confined to this one section — do not widen it.
+      continue;
     }
     if (c.heading !== a.heading) {
       problems.push(


### PR DESCRIPTION
## Summary

자작 스킬 [CaesiumY/agents-md-optimizer](https://github.com/CaesiumY/agents-md-optimizer)를 레포에 벤더링하고, 그 스킬로 `CLAUDE.md`·`AGENTS.md`를 discoverability filter 기준으로 최적화했습니다.

### 최적화 결과 (wc -l 기준)

| 지표 | Before | After | 변화 |
|------|--------|-------|------|
| CLAUDE.md 총 줄 수 | 208 | 74 | **−64%** |
| AGENTS.md 총 줄 수 | 209 | 72 | **−66%** |
| 섹션 수 | 29 | 10 | −66% |
| discoverable 줄 | ~110 | 0 | 제거 |
| gotcha 항목 | 0 | 15 | **추가** |

### 제거된 것 중 오정보 3건 (문서 부패 실증)

| 문서 내용 | 실제 |
|-----------|------|
| Astro v5.12.0 / TS v5.8.3 | Astro ~6.4.3 / TS ~6.0.3 (package.json) |
| frontmatter `pubDate`/`updatedDate`/`heroImage` | `pubDatetime`/`modDatetime`/`ogImage` (content.config.ts) — 문서대로 쓰면 빌드 실패 |
| 사이트 URL caesiumy.github.io | caesiumy.dev (src/config.ts) |

### 추가된 gotcha 15건 (소스 채굴 + main #77 통합)

- **View Transitions 리스너 규칙 3종** — PR #75/#76 수정에서 증류, `e2e/listener-leak.spec.ts` 불변량 연계
- **`markdown.processor: unified({...})` 필수** (Astro 6.4+, 구 remarkPlugins 키 deprecated) — main #77에서 통합
- pagefind dev 검색은 선행 `pnpm build` 필요 (public/pagefind gitignored)
- `_` 프리픽스 md는 컬렉션에서 완전 제외 + MDX 미지원 (`.md` 전용)
- 예약 발행은 빌드 시점 의존 — 재배포 없으면 영원히 비표시
- OG 이미지는 로컬 폰트 3개 필수, 없으면 빌드 실패
- CI 머지 게이트는 `Code standards & build` 단일 잡, Claude Review는 비차단
- Windows `pnpm format` CRLF 림보 — `git diff`로 판정
- Playwright는 dev 서버 대상, 픽스처가 실제 포스트 슬러그 의존 등

### 형식 제약 (Opus 전환 대비)

6/22 이후 Opus 복귀를 고려해 모델 비종속 형태로 작성: `##` 계층 + 자기완결 명령형 불릿, 금지 규칙엔 같은 줄 대안 병기, 패턴 출처 파일명 명시, ⚠️ 마커는 2개로 절제.

### 리뷰 반영 이력

- **claude[bot]**: `PUBLIC_GOOGLE_ANALYTICS_ID` 실존 검증 완료(astro.config.ts env 스키마), dding-dong 예시 주석은 업스트림 항목으로 분류
- **gemini-code-assist 인라인 4건 수용** (101a792): line-count.mjs trailing newline 과대측정 수정, 섹션 줄 수 off-by-one +1 (2곳), SKILL.md find 폴백에 알려진 경로 우선 + node_modules prune — 이 보정으로 위 표 수치가 `wc -l` 기준으로 통일됨
- **ESLint**: `.claude/skills/**/scripts/**` 한정 no-console 오버라이드 추가 (CLI 스크립트는 console 출력이 인터페이스, 사용자 승인)

### 업스트림 패치 권장 (CaesiumY/agents-md-optimizer)

벤더 사본에 적용된 수정 전부 업스트림 반영 후보: ① `split(/\r?\n/)` CRLF 패치 (Windows에서 sectionCount 항상 0 버그), ② 통계 산식 3건, ③ find 폴백 prune, ④ references 파일 dding-dong 출처 주석.

## Verification

- 합성 케이스로 산식 검증 (섹션 3줄/2줄, total 7 정확) + 실파일 `wc -l` 일치 ✓
- `pnpm lint` 통과 ✓ / prettier 통과 ✓
- 두 파일 diff — 의도된 도구별 치환(.claude↔.agents, 스킬 목록)만 존재 ✓
- `pnpm build` 생략: CLAUDE.md/AGENTS.md는 빌드 입력이 아님 — CI가 풀 빌드+e2e로 재확인